### PR TITLE
ci(dependabot): consolidate into a single grouped PR and fix ecosystem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners are automatically requested for review on pull requests.
+# This replaces the Dependabot `reviewers` option, which GitHub retired in August 2025.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @dawidrylko

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,29 @@
 version: 2
 updates:
-  - package-ecosystem: 'pnpm'
+  - package-ecosystem: 'npm' # covers npm/yarn/pnpm; resolved via pnpm-lock.yaml
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
       time: '03:00'
-    open-pull-requests-limit: 10
+      timezone: 'Europe/Warsaw'
+    # Single grouped PR for every weekly version update.
+    open-pull-requests-limit: 1
     assignees:
       - 'dawidrylko'
-    reviewers:
-      - 'dawidrylko'
-    rebase-strategy: auto
+    rebase-strategy: 'auto'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
     groups:
-      lint:
-        dependency-type: 'development'
+      all-dependencies:
+        applies-to: version-updates
         patterns:
-          - '@eslint/*'
-          - 'eslint*'
-      typescript:
-        dependency-type: 'development'
-        patterns:
-          - '@types/*'
+          - '*'
     ignore:
+      # Pinned to 0.13.3 for gatsby-remark-katex compatibility — do not bump.
       - dependency-name: 'katex'
+      # React 19 requires a coordinated migration; skip majors for now.
       - dependency-name: 'react'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-dom'


### PR DESCRIPTION
- Fix package-ecosystem from the unsupported 'pnpm' value to 'npm'
  (the npm ecosystem resolves pnpm projects via pnpm-lock.yaml)
- Group all version updates into one PR per week via a catch-all group
  and set open-pull-requests-limit to 1
- Keep katex pinned and skip react/react-dom majors (unchanged)
- Add Europe/Warsaw timezone and conventional commit prefix
- Replace the retired 'reviewers' option with a CODEOWNERS file