### PR TITLE
feat: per-instance mermaid rendering with error boundary and a11y

### DIFF
--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,41 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode | ((error: Error) => ReactNode);
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+// React error boundaries must be class components — they rely on the
+// getDerivedStateFromError / componentDidCatch lifecycle hooks.
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  render(): ReactNode {
+    const { error } = this.state;
+    const { children, fallback } = this.props;
+
+    if (error) {
+      if (typeof fallback === 'function') {
+        return fallback(error);
+      }
+      return fallback ?? null;
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -1,21 +1,89 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 import mermaid from 'mermaid';
+import ErrorBoundary from './error-boundary';
 
-const MermaidDiagram = ({ chart }: { chart: string }) => {
-  const ref = useRef(null);
+interface MermaidDiagramProps {
+  chart: string;
+  ariaLabel?: string;
+}
+
+let mermaidInitialized = false;
+
+// Initialize mermaid a single time with startOnLoad disabled — every diagram
+// is rendered explicitly per instance via mermaid.render, so the global
+// contentLoaded scan must never run.
+const initializeMermaid = (): void => {
+  if (mermaidInitialized) {
+    return;
+  }
+
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: 'default',
+    securityLevel: 'strict',
+  });
+  mermaidInitialized = true;
+};
+
+const Fallback: React.FC<{ chart: string; ariaLabel: string }> = ({ chart, ariaLabel }) => (
+  <pre className="mermaid-diagram-fallback" role="img" aria-label={ariaLabel}>
+    {chart}
+  </pre>
+);
+
+const MermaidDiagramInner: React.FC<Required<MermaidDiagramProps>> = ({ chart, ariaLabel }) => {
+  // Unique, DOM-safe id per instance so mermaid-generated class names and
+  // element ids never collide between diagrams on the same page.
+  const id = `mermaid-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
+  const [svg, setSvg] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
-    mermaid.initialize({ startOnLoad: true, theme: 'default' });
-    if (ref.current) {
-      mermaid.contentLoaded();
-    }
-  }, [chart]);
+    let cancelled = false;
+    setHasError(false);
+    setSvg(null);
+
+    const renderChart = async (): Promise<void> => {
+      try {
+        initializeMermaid();
+        const { svg: renderedSvg } = await mermaid.render(id, chart);
+        if (!cancelled) {
+          setSvg(renderedSvg);
+        }
+      } catch {
+        // Mermaid may leave an orphaned node behind when parsing fails.
+        document.getElementById(id)?.remove();
+        document.getElementById(`d${id}`)?.remove();
+        if (!cancelled) {
+          setHasError(true);
+        }
+      }
+    };
+
+    renderChart();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chart, id]);
+
+  if (hasError) {
+    return <Fallback chart={chart} ariaLabel={ariaLabel} />;
+  }
+
+  if (!svg) {
+    return null;
+  }
 
   return (
-    <div ref={ref} className="mermaid">
-      {chart}
-    </div>
+    <div className="mermaid-diagram" role="img" aria-label={ariaLabel} dangerouslySetInnerHTML={{ __html: svg }} />
   );
 };
+
+const MermaidDiagram: React.FC<MermaidDiagramProps> = ({ chart, ariaLabel = 'Diagram' }) => (
+  <ErrorBoundary fallback={<Fallback chart={chart} ariaLabel={ariaLabel} />}>
+    <MermaidDiagramInner chart={chart} ariaLabel={ariaLabel} />
+  </ErrorBoundary>
+);
 
 export default MermaidDiagram;

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -201,7 +201,7 @@ const SetupPage: React.FC<PageProps> = ({ location }) => {
         </section>
 
         <section id="diagram" aria-labelledby="diagram-heading">
-          <MermaidDiagram chart={setupDiagram} />
+          <MermaidDiagram chart={setupDiagram} ariaLabel="Hardware setup workflow diagram" />
         </section>
 
         <figure style={{ margin: '0' }}>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -645,6 +645,30 @@ blockquote {
   }
 }
 
+/* Mermaid diagrams */
+
+.mermaid-diagram {
+  display: flex;
+  justify-content: center;
+  margin: var(--spacing-6) 0;
+}
+
+.mermaid-diagram svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.mermaid-diagram-fallback {
+  overflow-x: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mermaid-diagram svg * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
 /* Footer */
 
 .footer {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -6,6 +6,7 @@ import { WithContext, BlogPosting, Person } from 'schema-dts';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
+import ErrorBoundary from '../components/error-boundary';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useStructuredData } from '../hooks/use-structured-data';
 
@@ -76,7 +77,9 @@ const BlogPostTemplate: React.FC<PageProps<Data>> = ({ data, location, children 
           </small>
         </header>
         {img && <GatsbyImage image={img} alt={post.frontmatter.featuredImgAlt || ''} />}
-        <section>{children}</section>
+        <ErrorBoundary fallback={<p>Nie udało się wyświetlić tej części treści.</p>}>
+          <section>{children}</section>
+        </ErrorBoundary>
       </article>
       <nav className="blog-post-nav">
         <ul


### PR DESCRIPTION
Rewrite MermaidDiagram to render each diagram explicitly via
mermaid.render(id, chart) instead of the global startOnLoad/contentLoaded
scan. Mermaid is now initialized once with startOnLoad: false, and every
instance gets a unique DOM-safe id so generated class names and element
ids no longer collide between diagrams on the same page.

- Add a generic ErrorBoundary component and wrap both the diagram and the
  blog post content with it.
- Show the diagram source in a <pre> fallback when parsing fails, so a
  broken diagram no longer crashes the render.
- Add role="img" + aria-label and respect prefers-reduced-motion.