### PR TITLE
refactor(blog): remove dangerouslySetInnerHTML from blog list

### DIFF
--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -132,11 +132,7 @@ const BlogIndex: React.FC<PageProps<DataProps>> = ({ data, location }) => {
                 </header>
                 <section>
                   {img && <GatsbyImage image={img} alt={post.frontmatter.featuredImgAlt || ''} />}
-                  <p
-                    dangerouslySetInnerHTML={{
-                      __html: description || '',
-                    }}
-                  />
+                  <p>{description}</p>
                 </section>
               </article>
             </li>


### PR DESCRIPTION
Replace dangerouslySetInnerHTML with a plain <p>{description}</p> on the
blog index. The description/excerpt come from frontmatter and are plain
text, so rendering them as HTML was unnecessary risk and could lead to
double-encoded entities. The RSS feed in gatsby-config.ts also treats the
description as plain text, so behavior stays consistent.