### PR TITLE
ci: add eslint check and fix lint-staged scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        check: ['type:check', 'format:check']
+        check: ['type:check', 'format:check', 'lint:check']
         node: ['24']
 
     steps:

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,json,md}": "prettier --write",
-    "**/*.{js,jsx,ts,tsx}": "eslint . --fix"
+    "**/*.{js,jsx,ts,tsx}": "eslint --fix"
   }
 }


### PR DESCRIPTION
Add a lint:check step to the CI matrix so ESLint runs on pull
requests alongside type:check and format:check.

Change the lint-staged entry from "eslint . --fix" to
"eslint --fix" so only staged files are linted instead of the
whole project (lint-staged appends file paths, which "eslint ."
ignored, making pre-commit slow and misleading).