### PR TITLE
feat: validate post frontmatter at build time with zod

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Te fakty są potrzebne, gdy modyfikujesz szablony, `gatsby-node.ts`, RSS lub sit
 - **Style:** czyste CSS z custom properties (design tokens), bez preprocesorów; Montserrat (nagłówki), Merriweather (tekst).
 - **Dane strukturalne:** react-schemaorg + schema-dts (JSON-LD).
 - **Prettier (TS/TSX):** single quotes, średniki, 2 spacje, `printWidth: 120`, `arrowParens: avoid`.
+- **Komentarze:** tylko po angielsku i tylko te realnie wartościowe — wyjaśniaj „dlaczego”, a nie to, co kod już mówi sam.
 
 ## Czego nie zmieniać
 

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -8,11 +8,10 @@ import { z } from 'zod';
 
 const blogPost = path.resolve(`./src/templates/blog-post.tsx`);
 
-// Walidacja frontmatteru postów (MDX/MD). Build ma failować z czytelnym
-// komunikatem, gdy brakuje wymaganego pola lub gdy featuredImg nie ma alt-textu.
 const frontmatterSchema = z
   .object({
     title: z.string({ error: 'title is required and must be a string' }).trim().min(1, 'title must not be empty'),
+    // Optional: most legacy .md posts have no description; RSS falls back to excerpt.
     description: z
       .string({ error: 'description must be a string' })
       .trim()

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -4,8 +4,46 @@ import type { GatsbyNode } from 'gatsby';
 import path from 'path';
 import fs from 'fs';
 import { createFilePath } from 'gatsby-source-filesystem';
+import { z } from 'zod';
 
 const blogPost = path.resolve(`./src/templates/blog-post.tsx`);
+
+// Walidacja frontmatteru postów (MDX/MD). Build ma failować z czytelnym
+// komunikatem, gdy brakuje wymaganego pola lub gdy featuredImg nie ma alt-textu.
+const frontmatterSchema = z
+  .object({
+    title: z.string({ error: 'title is required and must be a string' }).trim().min(1, 'title must not be empty'),
+    description: z
+      .string({ error: 'description must be a string' })
+      .trim()
+      .min(1, 'description must not be empty')
+      .optional(),
+    date: z
+      .union([z.string(), z.date()], { error: 'date is required' })
+      .refine(value => !Number.isNaN(new Date(value as string | Date).getTime()), 'date must be a valid date'),
+    tags: z
+      .array(z.string({ error: 'each tag must be a string' }).trim().min(1, 'tags must not contain empty values'), {
+        error: 'tags is required and must be an array',
+      })
+      .min(1, 'tags must contain at least one value'),
+    featuredImg: z.string({ error: 'featuredImg must be a string' }).trim().min(1).optional(),
+    featuredImgAlt: z.string({ error: 'featuredImgAlt must be a string' }).trim().min(1).optional(),
+  })
+  .refine(data => !data.featuredImg || Boolean(data.featuredImgAlt), {
+    error: 'featuredImgAlt is required when featuredImg is set',
+    path: ['featuredImgAlt'],
+  });
+
+const validateFrontmatter = (frontmatter: unknown, filePath: string, reporter: any): void => {
+  const result = frontmatterSchema.safeParse(frontmatter);
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map(issue => `  - ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('\n');
+    reporter.panicOnBuild(`Invalid frontmatter in ${filePath}:\n${issues}`);
+  }
+};
 
 export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createNodeId, createContentDigest }) => {
   const { createNode } = actions;
@@ -112,10 +150,15 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
   }
 };
 
-export const onCreateNode: GatsbyNode['onCreateNode'] = ({ node, actions, getNode }) => {
+export const onCreateNode: GatsbyNode['onCreateNode'] = ({ node, actions, getNode, reporter }) => {
   if (node.internal.type !== `Mdx`) {
     return;
   }
+
+  const parent = node.parent ? getNode(node.parent) : undefined;
+  const sourceFilePath =
+    (parent?.absolutePath as string) ?? (node.internal.contentFilePath as string) ?? String(node.id);
+  validateFrontmatter((node as any).frontmatter, sourceFilePath, reporter);
 
   const { createNodeField } = actions;
   const filePath = createFilePath({ node, getNode });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-schemaorg": "^2.0.1",
-    "schema-dts": "^2.0.0"
+    "schema-dts": "^2.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       schema-dts:
         specifier: ^2.0.0
         version: 2.0.0(typescript@6.0.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -6920,6 +6923,9 @@ packages:
     resolution: {integrity: sha512-PgrBqosQLM3gN2xBFIMDLACRTV9c365VqityKKpSTWpwR+U4LAFR3rSVyEoscWlu3EzX9+Y0I86GXUKxpHFl6w==}
     engines: {node: '>=4.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
@@ -15420,6 +15426,8 @@ snapshots:
       is-ci: 2.0.0
       read: 1.0.7
       strip-ansi: 5.2.0
+
+  zod@4.4.3: {}
 
   zwitch@1.0.5: {}
 


### PR DESCRIPTION
Add a zod schema in gatsby-node.ts that validates each MDX/MD post's
frontmatter in onCreateNode: title, description, date, tags, and the
rule that featuredImgAlt is required whenever featuredImg is set.
Invalid frontmatter fails the build via reporter.panicOnBuild with a
message pointing to the offending file, preventing silent SEO/RSS
breakage from typos or missing fields.