### PR TITLE
ci: harden search engine notification scripts in deploy

### DIFF
--- a/.github/scripts/bing.sh
+++ b/.github/scripts/bing.sh
@@ -1,18 +1,60 @@
 #!/usr/bin/env bash
 set -o errexit
 set -o nounset
+set -o pipefail
 
+# --- Configuration ---------------------------------------------------------
 BASE_URL="https://dawidrylko.com"
 STATIC_PAGES=("bio" "blog" "contact" "metadata" "setup" "files")
 POSTS_DIR="../../../content/pl/"
 TMP_DIR="$(pwd)/tmp"
 TMP_FILE="$TMP_DIR/bing.json"
 
+BING_API_BASE_URL="https://ssl.bing.com/webmaster/api.svc/json"
+BING_SUBMIT_ENDPOINT="SubmitUrlbatch"
+
+# Retry tuning for network/API calls.
+MAX_RETRIES=4
+INITIAL_BACKOFF=2
+
 start_time=$(date +%s.%3N)
 
 log_error() {
-  echo "Error: $1"
+  echo "Error: $1" >&2
   exit 1
+}
+
+# Graceful, non-fatal exit (e.g. missing optional secret). The deploy has
+# already been published, so a skipped notification must not fail the job.
+skip() {
+  echo "Skip: $1"
+  exit 0
+}
+
+# Run a command, retrying with exponential backoff on failure.
+retry_with_backoff() {
+  local attempt=1
+  local delay=$INITIAL_BACKOFF
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$MAX_RETRIES" ]; then
+      echo "Command failed after ${attempt} attempt(s)." >&2
+      return 1
+    fi
+    echo "Attempt ${attempt}/${MAX_RETRIES} failed. Retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+# Validate required secrets up front; skip gracefully when absent.
+check_required_secrets() {
+  if [ -z "${BING_API_KEY:-}" ]; then
+    skip "BING_API_KEY is not set or is empty. Skipping Bing notification."
+  fi
 }
 
 # Create a temporary working directory
@@ -41,10 +83,6 @@ construct_submission_payload() {
     done
   fi
 
-  if [ -z "$json_content" ]; then
-    log_error "JSON content is empty."
-  fi
-
   json_content="${json_content%,}]}"
 
   echo "Constructed JSON Body:"
@@ -53,37 +91,42 @@ construct_submission_payload() {
   echo
 }
 
-# Check if Bing API key is set
-check_api_key() {
-  if [ -z "${BING_API_KEY:-}" ]; then
-    log_error "BING_API_KEY is not set or is empty. Please set the API key and run the script again."
-  fi
-}
+# Submit URLs to Bing search engine (single attempt; wrapped by retry helper).
+submit_attempt() {
+  local bing_api_url="${BING_API_BASE_URL}/${BING_SUBMIT_ENDPOINT}?apikey=${BING_API_KEY}"
+  local response http_code body
 
-# Submit URLs to Bing search engine
-submit_to_search_engine() {
-  local bing_api_url="https://ssl.bing.com/webmaster/api.svc/json/SubmitUrlbatch?apikey=${BING_API_KEY}"
-
-  echo "Submitting to Bing via URL Submission API..."
-  response=$(curl -s -w "%{http_code}" "$bing_api_url" \
+  response=$(curl -s -w "%{http_code}" --max-time 30 "$bing_api_url" \
     -H "Content-Type: application/json; charset=utf-8" \
-    -d "@$TMP_FILE" || log_error "Failed submitting to Bing API.")
+    -d "@$TMP_FILE") || { echo "curl request to Bing API failed." >&2; return 1; }
 
   http_code=${response: -3}
   body=${response::-3}
 
   echo "HTTP Response Code: $http_code"
   echo "API Response Body:"
-  echo "$body" | jq '.'
+  echo "$body" | jq '.' 2>/dev/null || echo "$body"
   echo
+
+  if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+    echo "Bing API returned non-success status: $http_code" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+submit_to_search_engine() {
+  echo "Submitting to Bing via URL Submission API..."
+  retry_with_backoff submit_attempt || log_error "Failed submitting to Bing API."
 }
 
 # Main execution
+check_required_secrets
 create_tmp_directory
 
 cd "$TMP_DIR" || log_error "Failed to change to temporary directory $TMP_DIR"
 
-check_api_key
 construct_submission_payload
 submit_to_search_engine
 

--- a/.github/scripts/google.sh
+++ b/.github/scripts/google.sh
@@ -1,18 +1,65 @@
 #!/usr/bin/env bash
 set -o errexit
 set -o nounset
+set -o pipefail
 
+# --- Configuration ---------------------------------------------------------
 BASE_URL="https://dawidrylko.com"
 STATIC_PAGES=("bio" "blog" "contact" "metadata" "setup" "files")
 POSTS_DIR="../../../content/pl/"
 TMP_DIR="$(pwd)/tmp"
 TMP_FILE="$TMP_DIR/google.csv"
 
+# Pinned easyindex-cli release (https://github.com/usk81/easyindex-cli).
+# Bump EASYINDEX_VERSION and EASYINDEX_SHA256 together when upgrading.
+EASYINDEX_VERSION="1.0.6"
+EASYINDEX_SHA256="5b50e5294f6786ed2885b589ceb74f34cb9cad401f4be7b03c674cfb6ab542b7"
+EASYINDEX_ARCHIVE="easyindex-cli_${EASYINDEX_VERSION}_linux_amd64.tar.gz"
+EASYINDEX_URL="https://github.com/usk81/easyindex-cli/releases/download/v${EASYINDEX_VERSION}/${EASYINDEX_ARCHIVE}"
+EASYINDEX_CLI="./easyindex-cli"
+
+# Retry tuning for network/API calls.
+MAX_RETRIES=4
+INITIAL_BACKOFF=2
+
 start_time=$(date +%s.%3N)
 
 log_error() {
-  echo "Error: $1"
+  echo "Error: $1" >&2
   exit 1
+}
+
+# Graceful, non-fatal exit (e.g. missing optional secret). The deploy has
+# already been published, so a skipped notification must not fail the job.
+skip() {
+  echo "Skip: $1"
+  exit 0
+}
+
+# Run a command, retrying with exponential backoff on failure.
+retry_with_backoff() {
+  local attempt=1
+  local delay=$INITIAL_BACKOFF
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$MAX_RETRIES" ]; then
+      echo "Command failed after ${attempt} attempt(s): $*" >&2
+      return 1
+    fi
+    echo "Attempt ${attempt}/${MAX_RETRIES} failed. Retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+# Validate required secrets up front; skip gracefully when absent.
+check_required_secrets() {
+  if [ -z "${GOOGLE_JSON_KEY_FILE:-}" ]; then
+    skip "GOOGLE_JSON_KEY_FILE is not set or is empty. Skipping Google notification."
+  fi
 }
 
 # Create a temporary working directory
@@ -23,24 +70,29 @@ create_tmp_directory() {
   fi
 }
 
-# Download https://github.com/usk81/easyindex-cli
+# Download and verify the pinned easyindex-cli binary.
 download_easyindex_cli() {
-  EASYINDEX_CLI="./easyindex-cli"
-  if [ ! -f "$EASYINDEX_CLI" ]; then
-    echo "Fetching easyindex-cli binary..."
-    curl -s -L "https://github.com/usk81/easyindex-cli/releases/download/v1.0.6/easyindex-cli_1.0.6_linux_amd64.tar.gz" | tar xz || log_error "Failed to download and extract easyindex-cli binary."
-    echo
+  if [ -x "$EASYINDEX_CLI" ]; then
+    return 0
   fi
+
+  echo "Fetching easyindex-cli v${EASYINDEX_VERSION}..."
+  retry_with_backoff curl -fsSL --max-time 60 -o "$EASYINDEX_ARCHIVE" "$EASYINDEX_URL" \
+    || log_error "Failed to download easyindex-cli binary."
+
+  echo "Verifying checksum..."
+  echo "${EASYINDEX_SHA256}  ${EASYINDEX_ARCHIVE}" | sha256sum -c - \
+    || log_error "Checksum verification failed for ${EASYINDEX_ARCHIVE}."
+
+  tar xzf "$EASYINDEX_ARCHIVE" || log_error "Failed to extract easyindex-cli binary."
+  echo
 }
 
-# Copy credentials file
-copy_credentials_file() {
+# Write the Google service account credentials from the environment.
+write_credentials_file() {
   echo "Using the GOOGLE_JSON_KEY_FILE environment variable..."
-  if [ -z "${GOOGLE_JSON_KEY_FILE:-}" ]; then
-    log_error "GOOGLE_JSON_KEY_FILE is not set or is empty. Exiting."
-  fi
-
-  echo "$GOOGLE_JSON_KEY_FILE" > "$TMP_DIR/credentials.json" || log_error "Failed to write to credentials file $TMP_DIR/credentials.json"
+  echo "$GOOGLE_JSON_KEY_FILE" > "$TMP_DIR/credentials.json" \
+    || log_error "Failed to write to credentials file $TMP_DIR/credentials.json"
 }
 
 # Construct submission payload
@@ -70,17 +122,19 @@ construct_submission_payload() {
 # Submit URLs to Google search engine
 submit_to_search_engine() {
   echo "Submitting to Google via Indexing API..."
-  "$EASYINDEX_CLI" google publish --csv "$TMP_FILE" -C "$TMP_DIR/credentials.json" || log_error "An error returned by easyindex-cli. Exiting."
+  retry_with_backoff "$EASYINDEX_CLI" google publish --csv "$TMP_FILE" -C "$TMP_DIR/credentials.json" \
+    || log_error "An error returned by easyindex-cli. Exiting."
   echo
 }
 
 # Main execution
+check_required_secrets
 create_tmp_directory
 
 cd "$TMP_DIR" || log_error "Failed to change to temporary directory $TMP_DIR"
 
 download_easyindex_cli
-copy_credentials_file
+write_credentials_file
 construct_submission_payload
 submit_to_search_engine
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Notifications run after a successful deploy; a failure here must never
+      # roll back or block the already-published build, so they are non-blocking.
       - name: Notify Google via Indexing API
+        continue-on-error: true
         env:
           GOOGLE_JSON_KEY_FILE: ${{ secrets.GOOGLE_JSON_KEY_FILE }}
         working-directory: '.github/scripts'
@@ -94,6 +97,7 @@ jobs:
         run: ./google.sh
 
       - name: Notify Bing via URL Submission API
+        continue-on-error: true
         env:
           BING_API_KEY: ${{ secrets.BING_API_KEY }}
         working-directory: '.github/scripts'


### PR DESCRIPTION
Make the post-deploy Google/Bing notification steps resilient so an API
or configuration error can never roll back or block an already-published
build.

- Validate required secrets up front and skip gracefully (exit 0) with a
  clear message when absent, instead of crashing.
- Add exponential-backoff retry for API calls and the binary download.
- Pin easyindex-cli to v1.0.6 and verify its SHA-256 checksum after
  download.
- Extract API base URL/endpoint and binary version/URL/checksum into
  variables.
- Mark both notify steps continue-on-error so a failed notification does
  not fail the deploy workflow.