### PR TITLE
feat(eslint): add jsx-a11y and type-aware linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,22 +1,35 @@
 import globals from 'globals';
 import pluginJs from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 
-/** @type {import('eslint').Linter.Config[]} */
-export default [
+export default tseslint.config(
   {
-    files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+    ignores: ['.cache/**/*', 'content/**/*', 'helpers/**/venv/**/*', 'node_modules/**/*', 'public/**/*'],
   },
-  {
-    ignores: [
-      ".cache/**/*",
-      "content/**/*",
-      "helpers/**/venv/**/*",
-      "node_modules/**/*",
-      "public/**/*",
-    ],
-  },
-  { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-];
+  ...tseslint.configs.recommendedTypeChecked,
+  jsxA11y.flatConfigs.recommended,
+  {
+    languageOptions: {
+      globals: { ...globals.browser },
+      parserOptions: {
+        // gatsby-browser/ssr live at the repo root and are intentionally kept out of
+        // tsconfig (their CSS/font side-effect imports have no type declarations); the
+        // default project gives them type information for type-aware linting.
+        projectService: {
+          allowDefaultProject: ['gatsby-browser.tsx', 'gatsby-ssr.tsx'],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    // Config files run in Node and carry no type-aware program; disable type-checked rules for them.
+    files: ['**/*.{js,mjs,cjs}'],
+    extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+);

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,7 +1,44 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { GatsbyConfig } from 'gatsby';
 import { GTAG } from './src/constants/gtag';
 import { SITE_METADATA } from './src/constants/site-metadata';
+
+type GatsbyImageData = {
+  images?: {
+    fallback?: { src?: string };
+    sources?: Array<{ srcSet?: string }>;
+  };
+};
+
+type FeedQuery = {
+  site: { siteMetadata: { siteUrl: string } };
+  posts: {
+    nodes: Array<{
+      fields: { slug: string };
+      frontmatter: {
+        title: string;
+        description?: string;
+        date: string;
+        tags?: string[];
+        featuredImg?: { childImageSharp?: { gatsbyImageData?: GatsbyImageData } };
+      };
+      excerpt: string;
+    }>;
+  };
+};
+
+type RssEnclosure = { url: string; type: string; length: string };
+
+type RssItem = {
+  title: string;
+  description: string;
+  url: string;
+  guid: string;
+  author: string;
+  date: string;
+  custom_elements: Array<Record<string, unknown>>;
+  categories?: string[];
+  enclosure?: RssEnclosure;
+};
 
 const config: GatsbyConfig = {
   siteMetadata: {
@@ -130,7 +167,7 @@ const config: GatsbyConfig = {
                 }
               }
             `,
-            serialize: ({ query: { site, posts } }: any) => {
+            serialize: ({ query: { site, posts } }: { query: FeedQuery }) => {
               const getImageMimeType = (src: string): string => {
                 const extension = src.split('.').pop()?.toLowerCase();
                 switch (extension) {
@@ -148,7 +185,7 @@ const config: GatsbyConfig = {
                 }
               };
 
-              const getEnclosure = (gatsbyImageData: any) => {
+              const getEnclosure = (gatsbyImageData: GatsbyImageData | undefined): RssEnclosure | undefined => {
                 // Prefer the fallback (jpeg/png) variant for broad feed-reader compatibility,
                 // falling back to the largest srcSet candidate when it is unavailable.
                 const fallbackSrc: string | undefined = gatsbyImageData?.images?.fallback?.src;
@@ -170,14 +207,14 @@ const config: GatsbyConfig = {
                 };
               };
 
-              return posts.nodes.map((node: any) => {
+              return posts.nodes.map((node): RssItem => {
                 const url = `${site.siteMetadata.siteUrl}${node.fields.slug}`;
                 const description = node.frontmatter.description || node.excerpt;
                 const content = `<p>${description}</p><div style='margin-top: 50px; font-style: italic;'><strong><a href='${url}'>Czytaj dalej</a>.</strong></div><br /> <br />`;
                 const categories = node.frontmatter.tags || [];
                 const enclosure = getEnclosure(node.frontmatter.featuredImg?.childImageSharp?.gatsbyImageData);
 
-                const rssItem: any = {
+                const rssItem: RssItem = {
                   title: node.frontmatter.title,
                   description,
                   url,

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import type { GatsbyNode } from 'gatsby';
+import type { GatsbyNode, Reporter } from 'gatsby';
 
 import path from 'path';
 import fs from 'fs';
@@ -19,7 +18,7 @@ const frontmatterSchema = z
       .optional(),
     date: z
       .union([z.string(), z.date()], { error: 'date is required' })
-      .refine(value => !Number.isNaN(new Date(value as string | Date).getTime()), 'date must be a valid date'),
+      .refine(value => !Number.isNaN(new Date(value).getTime()), 'date must be a valid date'),
     tags: z
       .array(z.string({ error: 'each tag must be a string' }).trim().min(1, 'tags must not contain empty values'), {
         error: 'tags is required and must be an array',
@@ -33,7 +32,7 @@ const frontmatterSchema = z
     path: ['featuredImgAlt'],
   });
 
-const validateFrontmatter = (frontmatter: unknown, filePath: string, reporter: any): void => {
+const validateFrontmatter = (frontmatter: unknown, filePath: string, reporter: Reporter): void => {
   const result = frontmatterSchema.safeParse(frontmatter);
 
   if (!result.success) {
@@ -44,7 +43,7 @@ const validateFrontmatter = (frontmatter: unknown, filePath: string, reporter: a
   }
 };
 
-export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createNodeId, createContentDigest }) => {
+export const sourceNodes: GatsbyNode['sourceNodes'] = ({ actions, createNodeId, createContentDigest }) => {
   const { createNode } = actions;
   const filesDir = path.resolve('./static/files');
 
@@ -94,11 +93,22 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createNo
       relativePath: relativePath.replace(/\\/g, '/'),
     };
 
-    createNode(node);
+    void createNode(node);
   });
 };
 
-export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions, reporter }: any) => {
+type AllMdxQuery = {
+  allMdx: {
+    nodes: Array<{
+      id: string;
+      fields: { slug: string };
+      internal: { contentFilePath: string };
+    }>;
+  };
+};
+
+export const createPages: GatsbyNode['createPages'] = async gatsbyApi => {
+  const { actions, reporter } = gatsbyApi;
   const { createPage, createRedirect } = actions;
 
   createRedirect({
@@ -108,7 +118,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
     redirectInBrowser: true,
   });
 
-  const result = await graphql(`
+  const result = await gatsbyApi.graphql<AllMdxQuery>(`
     query AllMdx {
       allMdx(sort: { frontmatter: { date: ASC } }, limit: 1000) {
         nodes {
@@ -124,29 +134,27 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
     }
   `);
 
-  if (result.errors) {
-    reporter.panicOnBuild(`There was an error loading your blog posts`, result.errors);
+  if (result.errors || !result.data) {
+    reporter.panicOnBuild(`There was an error loading your blog posts`, result.errors as Error | Error[] | undefined);
     return;
   }
 
-  const posts: any[] = result.data.allMdx.nodes;
+  const posts = result.data.allMdx.nodes;
 
-  if (posts.length > 0) {
-    posts.forEach((post, index) => {
-      const previousPostId = index === 0 ? null : posts[index - 1].id;
-      const nextPostId = index === posts.length - 1 ? null : posts[index + 1].id;
+  posts.forEach((post, index) => {
+    const previousPostId = index === 0 ? null : posts[index - 1].id;
+    const nextPostId = index === posts.length - 1 ? null : posts[index + 1].id;
 
-      createPage({
-        path: post.fields.slug,
-        component: `${blogPost}?__contentFilePath=${post.internal.contentFilePath}`,
-        context: {
-          id: post.id,
-          previousPostId,
-          nextPostId,
-        },
-      });
+    createPage({
+      path: post.fields.slug,
+      component: `${blogPost}?__contentFilePath=${post.internal.contentFilePath}`,
+      context: {
+        id: post.id,
+        previousPostId,
+        nextPostId,
+      },
     });
-  }
+  });
 };
 
 export const onCreateNode: GatsbyNode['onCreateNode'] = ({ node, actions, getNode, reporter }) => {
@@ -157,7 +165,7 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = ({ node, actions, getNod
   const parent = node.parent ? getNode(node.parent) : undefined;
   const sourceFilePath =
     (parent?.absolutePath as string) ?? (node.internal.contentFilePath as string) ?? String(node.id);
-  validateFrontmatter((node as any).frontmatter, sourceFilePath, reporter);
+  validateFrontmatter((node as { frontmatter?: unknown }).frontmatter, sourceFilePath, reporter);
 
   const { createNodeField } = actions;
   const filePath = createFilePath({ node, getNode });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.5.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "prettier": "^3.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       eslint:
         specifier: ^10.5.0
         version: 10.5.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@10.5.0)
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -10752,7 +10755,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@10.5.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3):
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@10.5.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.5.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
       '@typescript-eslint/parser': 5.62.0(eslint@10.5.0)(typescript@6.0.3)
@@ -10831,6 +10834,25 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 10.5.0
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.12.0
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 7.32.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -11794,10 +11816,10 @@ snapshots:
       enhanced-resolve: 5.23.0
       error-stack-parser: 2.1.4
       eslint: 7.32.0
-      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@10.5.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3)
+      eslint-config-react-app: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(babel-eslint@10.1.0(eslint@10.5.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.5.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.5(eslint@7.32.0))(eslint@7.32.0)(typescript@6.0.3)
       eslint-plugin-flowtype: 5.10.0(eslint@10.5.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.5.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.5(eslint@10.5.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@10.5.0)
       eslint-webpack-plugin: 2.7.0(eslint@7.32.0)(webpack@5.98.0(postcss@8.5.15))

--- a/src/components/bio.tsx
+++ b/src/components/bio.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { Person, WithContext } from 'schema-dts';
+import { Person } from 'schema-dts';
 import { StaticImage } from 'gatsby-plugin-image';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useStructuredData } from '../hooks/use-structured-data';
 
 const Bio: React.FC = () => {
   const { siteAuthor, siteSocial } = useSiteMetadata();
-  const { person } = useStructuredData() as { person: WithContext<Person> };
+  const { person } = useStructuredData();
 
   return (
     <div className="bio">

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -60,7 +60,7 @@ const MermaidDiagramInner: React.FC<Required<MermaidDiagramProps>> = ({ chart, a
       }
     };
 
-    renderChart();
+    void renderChart();
 
     return () => {
       cancelled = true;

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -9,12 +9,12 @@ type TableProps = {
 
 const Table: React.FC<TableProps> = ({ data, header, widthConfig, ariaLabel }) => {
   return (
-    <table role="table" aria-label={ariaLabel}>
+    <table aria-label={ariaLabel}>
       {header && (
         <thead>
-          <tr role="row">
+          <tr>
             {header.map((item, index) => (
-              <th key={index} scope="col" role="columnheader">
+              <th key={index} scope="col">
                 {item}
               </th>
             ))}
@@ -23,9 +23,9 @@ const Table: React.FC<TableProps> = ({ data, header, widthConfig, ariaLabel }) =
       )}
       <tbody>
         {data.map((row, rowIndex) => (
-          <tr key={rowIndex} role="row">
+          <tr key={rowIndex}>
             {row.map((cell, cellIndex) => (
-              <td key={cellIndex} width={widthConfig?.[cellIndex]} role="cell">
+              <td key={cellIndex} width={widthConfig?.[cellIndex]}>
                 {cell}
               </td>
             ))}

--- a/src/constants/structured-data.ts
+++ b/src/constants/structured-data.ts
@@ -1,3 +1,4 @@
+import type { Person, WithContext } from 'schema-dts';
 import { SITE_METADATA } from './site-metadata';
 
 export const STRUCTURED_DATA = {
@@ -71,4 +72,4 @@ export const STRUCTURED_DATA = {
     },
     sameAs: SITE_METADATA.social.map(social => social.url),
   },
-};
+} satisfies { person: WithContext<Person> };

--- a/src/demo/memoization-demo.tsx
+++ b/src/demo/memoization-demo.tsx
@@ -173,7 +173,7 @@ const MemoizationDemo: React.FC = () => {
               {horcruxList.map(horcrux => (
                 <button
                   key={horcrux}
-                  onClick={() => viewHorcrux(horcrux)}
+                  onClick={() => void viewHorcrux(horcrux)}
                   disabled={loadingHorcruxes.has(horcrux)}
                   className={`harry-potter-horcrux-btn ${loadingHorcruxes.has(horcrux) ? `harry-potter-loading` : ``}`}
                 >

--- a/src/hooks/use-site-metadata.tsx
+++ b/src/hooks/use-site-metadata.tsx
@@ -21,7 +21,7 @@ type SiteMetadata = {
 };
 
 export const useSiteMetadata = (): SiteMetadata => {
-  const data = useStaticQuery(graphql`
+  const data = useStaticQuery<{ site: { siteMetadata: SiteMetadata } }>(graphql`
     query SiteMetadata {
       site {
         siteMetadata {

--- a/src/pages/bio.tsx
+++ b/src/pages/bio.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { Person, WebPage, WithContext } from 'schema-dts';
+import { WebPage, WithContext } from 'schema-dts';
 import type { PageProps, HeadFC } from 'gatsby';
 import { StaticImage } from 'gatsby-plugin-image';
 
@@ -73,8 +73,7 @@ const image = {
 };
 
 const BioPage: React.FC<PageProps> = ({ location }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { person } = useStructuredData() as { person: WithContext<Person> } as { person: any };
+  const { person } = useStructuredData();
   const { siteAuthor } = useSiteMetadata();
 
   const structuredData: WithContext<WebPage> = {

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -2,7 +2,7 @@ import type { HeadFC, PageProps } from 'gatsby';
 
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { Person, Blog, WithContext } from 'schema-dts';
+import { Blog, WithContext } from 'schema-dts';
 import { Link, graphql } from 'gatsby';
 import { GatsbyImage, getImage, IGatsbyImageData, StaticImage } from 'gatsby-plugin-image';
 
@@ -53,7 +53,7 @@ const PAGE_METADATA = {
 
 const BlogIndex: React.FC<PageProps<DataProps>> = ({ data, location }) => {
   const { siteAuthor } = useSiteMetadata();
-  const { person } = useStructuredData() as { person: WithContext<Person> };
+  const { person } = useStructuredData();
   const posts = data?.allMdx.nodes;
 
   if (posts.length === 0) {

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -26,8 +26,7 @@ const PAGE_METADATA = {
 
 const ContactPage: React.FC<PageProps> = ({ location }) => {
   const { siteAuthor, siteSocial } = useSiteMetadata();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { person } = useStructuredData() as { person: any };
+  const { person } = useStructuredData();
 
   const structuredData: WithContext<WebPage> = {
     '@context': 'https://schema.org',

--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -218,8 +218,7 @@ const PresentationsPage: React.FC<PageProps<DataType>> = ({ data, location }) =>
     };
   }, []);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { person } = useStructuredData() as { person: any };
+  const { person } = useStructuredData();
 
   const structuredData: WithContext<CollectionPage> = {
     '@context': 'https://schema.org',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,8 +24,7 @@ const PAGE_METADATA = {
 };
 
 const BlogIndex: React.FC<PageProps> = ({ location }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { person } = useStructuredData() as { person: any };
+  const { person } = useStructuredData();
 
   const structuredData: WithContext<WebPage> = {
     '@context': 'https://schema.org',

--- a/src/pages/metadata.tsx
+++ b/src/pages/metadata.tsx
@@ -68,8 +68,7 @@ const PAGE_METADATA = {
 };
 
 const MetadataPage: React.FC<PageProps<DataType>> = ({ data, location }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { person } = useStructuredData() as { person: any };
+  const { person } = useStructuredData();
 
   const structuredData: WithContext<CollectionPage> = {
     '@context': 'https://schema.org',

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -145,8 +145,7 @@ const setupDiagram = `graph TD
 `;
 
 const SetupPage: React.FC<PageProps> = ({ location }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { person } = useStructuredData() as { person: any };
+  const { person } = useStructuredData();
 
   const structuredData: WithContext<CollectionPage> = {
     '@context': 'https://schema.org',

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link, graphql, PageProps, HeadProps } from 'gatsby';
 import { GatsbyImage, getImage, IGatsbyImageData } from 'gatsby-plugin-image';
 import { JsonLd } from 'react-schemaorg';
-import { WithContext, BlogPosting, Person } from 'schema-dts';
+import { WithContext, BlogPosting } from 'schema-dts';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
@@ -36,7 +36,7 @@ type Data = {
 
 const BlogPostTemplate: React.FC<PageProps<Data>> = ({ data, location, children }) => {
   const { siteAuthor } = useSiteMetadata();
-  const { person } = useStructuredData() as { person: WithContext<Person> };
+  const { person } = useStructuredData();
   const { previous, next, mdx: post } = data;
 
   const img = getImage(post.frontmatter.featuredImg?.childImageSharp?.gatsbyImageData || null);


### PR DESCRIPTION
Enable eslint-plugin-jsx-a11y (flat config) and typescript-eslint
recommended-type-checked via projectService, then resolve all resulting
a11y and type-safety violations.

- type STRUCTURED_DATA.person with `satisfies WithContext<Person>` so the
  `as { person: any }` casts and per-file no-explicit-any disables can be
  dropped across pages, bio and blog-post
- type the GraphQL results in gatsby-node, gatsby-config and
  use-site-metadata instead of `any`, removing the file-level disables
- drop redundant ARIA roles from the table component
- mark intentionally fire-and-forget promises with `void`
- keep gatsby-browser/ssr out of tsconfig but type-aware-lint them via
  the default project

All eslint-disable comments removed; lint:check, type:check and
format:check are green.