### PR TITLE
build(ts): modernize tsconfig and adopt automatic JSX runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Te fakty są potrzebne, gdy modyfikujesz szablony, `gatsby-node.ts`, RSS lub sit
 
 ## Konwencje kodu
 
-- **Komponenty:** `React.FC` z interfejsem TypeScript, nazwy PascalCase.
+- **Komponenty:** typ `FC` (named import z `react`) z interfejsem TypeScript, nazwy PascalCase. Automatic JSX runtime (`jsx: react-jsx` + `jsxRuntime: 'automatic'` w gatsby-config) — bez `import * as React`; hooki, `Fragment`, `ReactNode` itp. importuj imiennie.
 - **Pliki:** kebab-case (np. `mermaid-diagram.tsx`). **Stałe:** UPPER_SNAKE_CASE.
 - **Style:** czyste CSS z custom properties (design tokens), bez preprocesorów; Montserrat (nagłówki), Merriweather (tekst).
 - **Dane strukturalne:** react-schemaorg + schema-dts (JSON-LD).

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -41,6 +41,10 @@ type RssItem = {
 };
 
 const config: GatsbyConfig = {
+  // Compile JSX with the automatic runtime so React no longer needs to be in
+  // scope. This mirrors `jsx: react-jsx` in tsconfig (which only governs tsc);
+  // Gatsby's Babel pipeline defaults to the classic runtime otherwise.
+  jsxRuntime: 'automatic',
   siteMetadata: {
     siteUrl: `${SITE_METADATA.url}/`,
     siteTitle: SITE_METADATA.title,

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -142,8 +142,8 @@ export const createPages: GatsbyNode['createPages'] = async gatsbyApi => {
   const posts = result.data.allMdx.nodes;
 
   posts.forEach((post, index) => {
-    const previousPostId = index === 0 ? null : posts[index - 1].id;
-    const nextPostId = index === posts.length - 1 ? null : posts[index + 1].id;
+    const previousPostId = index === 0 ? null : (posts[index - 1]?.id ?? null);
+    const nextPostId = index === posts.length - 1 ? null : (posts[index + 1]?.id ?? null);
 
     createPage({
       path: post.fields.slug,

--- a/src/components/bio.tsx
+++ b/src/components/bio.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { Person } from 'schema-dts';
 import { StaticImage } from 'gatsby-plugin-image';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { useStructuredData } from '../hooks/use-structured-data';
 
-const Bio: React.FC = () => {
+const Bio: FC = () => {
   const { siteAuthor, siteSocial } = useSiteMetadata();
   const { person } = useStructuredData();
 

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { BreadcrumbList, WithContext } from 'schema-dts';
 import { Link } from 'gatsby';
@@ -16,7 +16,7 @@ type BreadcrumbsProps = {
   customTitle: string;
 };
 
-const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ location, customTitle }) => {
+const Breadcrumbs: FC<BreadcrumbsProps> = ({ location, customTitle }) => {
   const { siteUrl, menu } = useSiteMetadata();
 
   const generateBreadcrumbs = (): BreadcrumbItem[] => {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,4 @@
-import type { ReactNode } from 'react';
-
-import * as React from 'react';
+import type { FC, ReactNode } from 'react';
 import { Link } from 'gatsby';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import Bio from './bio';
@@ -15,7 +13,7 @@ type LayoutProps = {
 
 declare const __PATH_PREFIX__: string;
 
-const Layout: React.FC<LayoutProps> = ({ location, children, breadcrumbTitle }) => {
+const Layout: FC<LayoutProps> = ({ location, children, breadcrumbTitle }) => {
   const { siteUrl, siteAuthor } = useSiteMetadata();
   const rootPath = `${__PATH_PREFIX__}/`;
   const isRootPath = location.pathname === rootPath;

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { SiteNavigationElement, WithContext } from 'schema-dts';
 import { Link } from 'gatsby';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 
-const Menu: React.FC = () => {
+const Menu: FC = () => {
   const { menu, siteUrl } = useSiteMetadata();
 
   const structuredData: WithContext<SiteNavigationElement> = {

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useId, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useId, useState } from 'react';
 import mermaid from 'mermaid';
 import ErrorBoundary from './error-boundary';
 
@@ -25,13 +26,13 @@ const initializeMermaid = (): void => {
   mermaidInitialized = true;
 };
 
-const Fallback: React.FC<{ chart: string; ariaLabel: string }> = ({ chart, ariaLabel }) => (
+const Fallback: FC<{ chart: string; ariaLabel: string }> = ({ chart, ariaLabel }) => (
   <pre className="mermaid-diagram-fallback" role="img" aria-label={ariaLabel}>
     {chart}
   </pre>
 );
 
-const MermaidDiagramInner: React.FC<Required<MermaidDiagramProps>> = ({ chart, ariaLabel }) => {
+const MermaidDiagramInner: FC<Required<MermaidDiagramProps>> = ({ chart, ariaLabel }) => {
   // Unique, DOM-safe id per instance so mermaid-generated class names and
   // element ids never collide between diagrams on the same page.
   const id = `mermaid-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
@@ -80,7 +81,7 @@ const MermaidDiagramInner: React.FC<Required<MermaidDiagramProps>> = ({ chart, a
   );
 };
 
-const MermaidDiagram: React.FC<MermaidDiagramProps> = ({ chart, ariaLabel = 'Diagram' }) => (
+const MermaidDiagram: FC<MermaidDiagramProps> = ({ chart, ariaLabel = 'Diagram' }) => (
   <ErrorBoundary fallback={<Fallback chart={chart} ariaLabel={ariaLabel} />}>
     <MermaidDiagramInner chart={chart} ariaLabel={ariaLabel} />
   </ErrorBoundary>

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC, ReactNode } from 'react';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
 import { SITE_METADATA } from '../constants/site-metadata';
 
@@ -10,7 +10,7 @@ type SeoProps = {
   image?: string;
   article?: boolean;
   noIndex?: boolean;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 // Square brand icon emitted by gatsby-plugin-manifest; used as the OG/Twitter
@@ -23,7 +23,7 @@ const OG_LOCALES: Record<string, string> = {
   pl: 'pl_PL',
 };
 
-const Seo: React.FC<SeoProps> = ({ lang, title, description, pathname, image, article, noIndex, children }) => {
+const Seo: FC<SeoProps> = ({ lang, title, description, pathname, image, article, noIndex, children }) => {
   const { siteUrl, siteTitle, siteDescription, siteSocial, siteAuthor } = useSiteMetadata();
 
   const metaLang = lang ?? SITE_METADATA.lang;

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
+import type { FC, ReactNode } from 'react';
 
 type TableProps = {
-  data: (string | React.ReactNode)[][];
+  data: (string | ReactNode)[][];
   header?: string[];
   widthConfig?: string[];
   ariaLabel?: string;
 };
 
-const Table: React.FC<TableProps> = ({ data, header, widthConfig, ariaLabel }) => {
+const Table: FC<TableProps> = ({ data, header, widthConfig, ariaLabel }) => {
   return (
     <table aria-label={ariaLabel}>
       {header && (

--- a/src/demo/memoization-demo.tsx
+++ b/src/demo/memoization-demo.tsx
@@ -18,7 +18,8 @@
  * "After all, to the well-organised mind, death is but the next great adventure."
  * And to the well-organised code, performance is but a cached memory.
  */
-import React, { useState, useCallback, useRef } from 'react';
+import type { FC } from 'react';
+import { useState, useCallback, useRef } from 'react';
 
 enum LogType {
   Processing,
@@ -63,7 +64,7 @@ const HORCRUX_DATA = new Map<string, string[]>([
 
 const WELCOME_MESSAGE = `🔮 Welcome to the Pensieve. Select a Horcrux to view its memories...`;
 
-const MemoizationDemo: React.FC = () => {
+const MemoizationDemo: FC = () => {
   const [logEntries, setLogEntries] = useState<LogEntry[]>([
     { id: 0, message: WELCOME_MESSAGE, type: LogType.Result, timestamp: Date.now(), isFinished: true },
   ]);

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { WebPage, WithContext } from 'schema-dts';
 import type { HeadFC, PageProps } from 'gatsby';
@@ -17,7 +17,7 @@ const hotDogImage = {
   caption: 'Photo by Dawid Ryłko, taken on September 8, 2017, in Crete, Greece.',
 };
 
-const NotFoundPage: React.FC<PageProps> = ({ location }) => {
+const NotFoundPage: FC<PageProps> = ({ location }) => {
   const structuredData: WithContext<WebPage> = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',

--- a/src/pages/bio.tsx
+++ b/src/pages/bio.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC } from 'react';
+import { Fragment } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { WebPage, WithContext } from 'schema-dts';
 import type { PageProps, HeadFC } from 'gatsby';
@@ -72,7 +73,7 @@ const image = {
   figcaption: `Photo by Dawid Ryłko, taken on September 7, 2017, in Malia, Greece.`,
 };
 
-const BioPage: React.FC<PageProps> = ({ location }) => {
+const BioPage: FC<PageProps> = ({ location }) => {
   const { person } = useStructuredData();
   const { siteAuthor } = useSiteMetadata();
 
@@ -187,18 +188,18 @@ const BioPage: React.FC<PageProps> = ({ location }) => {
           </p>
         </section>
         <section id="quote">
-          {citations.map(({ authorName, citation, text }, index) => (
+          {citations.map(({ authorName, citation, text, extraDetails }, index) => (
             <blockquote key={index}>
               {text}
               <br />
               <cite>
                 - {authorName}, {citation}
               </cite>
-              {citations[index].extraDetails?.map(({ type, note }) => (
-                <React.Fragment key={type}>
+              {extraDetails?.map(({ type, note }) => (
+                <Fragment key={type}>
                   <br />
                   <small>{note}</small>
-                </React.Fragment>
+                </Fragment>
               ))}
             </blockquote>
           ))}

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -1,6 +1,6 @@
 import type { HeadFC, PageProps } from 'gatsby';
 
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { Blog, WithContext } from 'schema-dts';
 import { Link, graphql } from 'gatsby';
@@ -51,7 +51,7 @@ const PAGE_METADATA = {
   ],
 };
 
-const BlogIndex: React.FC<PageProps<DataProps>> = ({ data, location }) => {
+const BlogIndex: FC<PageProps<DataProps>> = ({ data, location }) => {
   const { siteAuthor } = useSiteMetadata();
   const { person } = useStructuredData();
   const posts = data?.allMdx.nodes;

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,5 +1,5 @@
 import type { HeadFC, PageProps } from 'gatsby';
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { WithContext, WebPage } from 'schema-dts';
 
@@ -24,7 +24,7 @@ const PAGE_METADATA = {
   ],
 };
 
-const ContactPage: React.FC<PageProps> = ({ location }) => {
+const ContactPage: FC<PageProps> = ({ location }) => {
   const { siteAuthor, siteSocial } = useSiteMetadata();
   const { person } = useStructuredData();
 

--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -1,5 +1,6 @@
 import type { HeadFC, PageProps } from 'gatsby';
-import * as React from 'react';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { WithContext, CollectionPage } from 'schema-dts';
 import { graphql } from 'gatsby';
@@ -57,8 +58,15 @@ const parseFileName = (fileName: string): ParsedFileName | null => {
   }
 
   const topic = parts[0];
-  const order = parseInt(parts[1], 10);
-  const language = parts[parts.length - 1].toLowerCase();
+  const orderRaw = parts[1];
+  const languageRaw = parts[parts.length - 1];
+
+  if (topic === undefined || orderRaw === undefined || languageRaw === undefined) {
+    return null;
+  }
+
+  const order = parseInt(orderRaw, 10);
+  const language = languageRaw.toLowerCase();
   const title = parts.slice(2, -1).join('_');
 
   return {
@@ -102,12 +110,15 @@ const createPresentationsArray = ({ allStaticFile: { nodes } }: DataType, showHi
     const filesA = groupedFiles.get(keyA);
     const filesB = groupedFiles.get(keyB);
 
-    if (!filesA || !filesB) {
+    const firstA = filesA?.[0];
+    const firstB = filesB?.[0];
+
+    if (!firstA || !firstB) {
       return 0;
     }
 
-    const parsedA = parseFileName(filesA[0].name);
-    const parsedB = parseFileName(filesB[0].name);
+    const parsedA = parseFileName(firstA.name);
+    const parsedB = parseFileName(firstB.name);
 
     if (!parsedA || !parsedB) {
       return 0;
@@ -123,13 +134,18 @@ const createPresentationsArray = ({ allStaticFile: { nodes } }: DataType, showHi
   let index = 1;
 
   return sortedEntries.map(([, files]) => {
-    const parsed = parseFileName(files[0].name);
+    const firstFile = files[0];
+    if (!firstFile) {
+      return [];
+    }
+
+    const parsed = parseFileName(firstFile.name);
     if (!parsed) {
       return [];
     }
 
     const pdfFile = files.find(f => f.extension.toLowerCase() === 'pdf');
-    const sizeSource = pdfFile || files[0];
+    const sizeSource = pdfFile ?? firstFile;
 
     const downloadLinks = (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -200,10 +216,10 @@ const PAGE_METADATA = {
   ],
 };
 
-const PresentationsPage: React.FC<PageProps<DataType>> = ({ data, location }) => {
-  const [showHidden, setShowHidden] = React.useState(false);
+const PresentationsPage: FC<PageProps<DataType>> = ({ data, location }) => {
+  const [showHidden, setShowHidden] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.metaKey && e.shiftKey && e.key === '.') {
         e.preventDefault();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import type { HeadFC, PageProps } from 'gatsby';
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { WithContext, WebPage } from 'schema-dts';
 
@@ -23,7 +23,7 @@ const PAGE_METADATA = {
   ],
 };
 
-const BlogIndex: React.FC<PageProps> = ({ location }) => {
+const BlogIndex: FC<PageProps> = ({ location }) => {
   const { person } = useStructuredData();
 
   const structuredData: WithContext<WebPage> = {

--- a/src/pages/metadata.tsx
+++ b/src/pages/metadata.tsx
@@ -1,5 +1,5 @@
 import type { HeadFC, PageProps } from 'gatsby';
-import * as React from 'react';
+import type { FC } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { WithContext, CollectionPage } from 'schema-dts';
 import { graphql, Link } from 'gatsby';
@@ -67,7 +67,7 @@ const PAGE_METADATA = {
   ],
 };
 
-const MetadataPage: React.FC<PageProps<DataType>> = ({ data, location }) => {
+const MetadataPage: FC<PageProps<DataType>> = ({ data, location }) => {
   const { person } = useStructuredData();
 
   const structuredData: WithContext<CollectionPage> = {

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -1,6 +1,6 @@
 import type { HeadFC, PageProps } from 'gatsby';
 import { StaticImage } from 'gatsby-plugin-image';
-import * as React from 'react';
+import type { FC, ReactNode } from 'react';
 import { JsonLd } from 'react-schemaorg';
 import { WithContext, WebPage, CollectionPage } from 'schema-dts';
 
@@ -64,7 +64,7 @@ const image = {
   figcaption: `Photo by Dawid Ryłko, taken on January 3, 2026.`,
 };
 
-const transformSetupData = (data: SetupItem[]): (string | React.ReactNode)[][] => {
+const transformSetupData = (data: SetupItem[]): (string | ReactNode)[][] => {
   return data.map(([type, name, link, details]) => {
     const linkElement = link ? (
       <a href={link} target="_blank" rel="noopener noreferrer" aria-label={`View ${name} on external site`}>
@@ -144,7 +144,7 @@ const setupDiagram = `graph TD
   Monitor -- "USB-A ↔ USB-C<br/><small>Light Bar cable</small>" --> Lightbar
 `;
 
-const SetupPage: React.FC<PageProps> = ({ location }) => {
+const SetupPage: FC<PageProps> = ({ location }) => {
   const { person } = useStructuredData();
 
   const structuredData: WithContext<CollectionPage> = {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { Link, graphql, PageProps, HeadProps } from 'gatsby';
 import { GatsbyImage, getImage, IGatsbyImageData } from 'gatsby-plugin-image';
 import { JsonLd } from 'react-schemaorg';
@@ -34,7 +34,7 @@ type Data = {
   next: PostNode;
 };
 
-const BlogPostTemplate: React.FC<PageProps<Data>> = ({ data, location, children }) => {
+const BlogPostTemplate: FC<PageProps<Data>> = ({ data, location, children }) => {
   const { siteAuthor } = useSiteMetadata();
   const { person } = useStructuredData();
   const { previous, next, mdx: post } = data;
@@ -111,7 +111,7 @@ const BlogPostTemplate: React.FC<PageProps<Data>> = ({ data, location, children 
   );
 };
 
-export const Head: React.FC<HeadProps<Data>> = ({ data: { mdx: post }, location }) => (
+export const Head: FC<HeadProps<Data>> = ({ data: { mdx: post }, location }) => (
   <Seo
     lang="pl"
     title={post.frontmatter.title}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "esnext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": ["dom", "esnext"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "jsx": "react",                                /* Specify what JSX code is generated. */
+    "jsx": "react-jsx",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
@@ -33,7 +33,7 @@
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    "resolveJsonModule": true,                        /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
@@ -83,12 +83,12 @@
     // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
     // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */


### PR DESCRIPTION
- Switch jsx to react-jsx and set jsxRuntime: 'automatic' in gatsby-config
  so React no longer needs to be in scope (tsconfig's jsx only governs tsc;
  Gatsby's Babel pipeline defaults to the classic runtime).
- Replace `import * as React` / default React imports with named imports
  (FC, ReactNode, useState, useEffect, Fragment, ...) across all .tsx files.
- Enable resolveJsonModule, noUnusedLocals, noUnusedParameters and
  noUncheckedIndexedAccess; add the resulting undefined guards in files.tsx
  and gatsby-node.ts.
- Document the FC/named-import convention in CLAUDE.md.