### PR TITLE
refactor: drop useStructuredData hook and share schema/page-metadata types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,9 @@ Przed zatwierdzeniem zmian uruchom `pnpm type:check` i `pnpm format:check`. Nie 
 src/components/    # Komponenty React (layout, bio, menu, seo, breadcrumbs, table, mermaid-diagram)
 src/pages/         # Strony Gatsby (index, blog, bio, contact, setup, metadata, files, 404)
 src/templates/     # blog-post.tsx — szablon posta
-src/hooks/         # useSiteMetadata, useStructuredData
+src/hooks/         # useSiteMetadata
 src/constants/     # site-metadata.ts, structured-data.ts, gtag.tsx
+src/types/         # Współdzielone typy (page-metadata, structured-data)
 src/styles/        # main.css (design tokens — CSS custom properties), normalize.css
 content/pl/        # Posty blogowe MDX
 static/files/      # Pliki statyczne (prezentacje PDF/KEY/PPTX, CV)

--- a/src/components/bio.tsx
+++ b/src/components/bio.tsx
@@ -3,11 +3,11 @@ import { JsonLd } from 'react-schemaorg';
 import { Person } from 'schema-dts';
 import { StaticImage } from 'gatsby-plugin-image';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
 
 const Bio: React.FC = () => {
   const { siteAuthor, siteSocial } = useSiteMetadata();
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
 
   return (
     <div className="bio">

--- a/src/constants/structured-data.ts
+++ b/src/constants/structured-data.ts
@@ -1,4 +1,4 @@
-import type { Person, WithContext } from 'schema-dts';
+import type { PersonStructuredData } from '../types';
 import { SITE_METADATA } from './site-metadata';
 
 export const STRUCTURED_DATA = {
@@ -72,4 +72,4 @@ export const STRUCTURED_DATA = {
     },
     sameAs: SITE_METADATA.social.map(social => social.url),
   },
-} satisfies { person: WithContext<Person> };
+} satisfies { person: PersonStructuredData };

--- a/src/hooks/use-structured-data.tsx
+++ b/src/hooks/use-structured-data.tsx
@@ -1,5 +1,0 @@
-import { STRUCTURED_DATA } from '../constants/structured-data';
-
-export const useStructuredData = (): typeof STRUCTURED_DATA => {
-  return STRUCTURED_DATA;
-};

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { WebPage, WithContext } from 'schema-dts';
+import { WebPage } from 'schema-dts';
 import type { HeadFC, PageProps } from 'gatsby';
 import { StaticImage } from 'gatsby-plugin-image';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
+import type { PageMetadata, StructuredData } from '../types';
 
 const PAGE_METADATA = {
   title: 'Page Not Found',
   description: 'The page you are looking for does not exist. Maybe it went out for a hot dog... 🌭',
-};
+} satisfies PageMetadata;
 
 const hotDogImage = {
   alt: 'Statue of a smiling hot dog character with arms, legs, and a face, sitting on a rock.',
@@ -18,7 +19,7 @@ const hotDogImage = {
 };
 
 const NotFoundPage: React.FC<PageProps> = ({ location }) => {
-  const structuredData: WithContext<WebPage> = {
+  const structuredData: StructuredData<WebPage> = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     name: PAGE_METADATA.title,

--- a/src/pages/bio.tsx
+++ b/src/pages/bio.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { WebPage, WithContext } from 'schema-dts';
+import { WebPage } from 'schema-dts';
 import type { PageProps, HeadFC } from 'gatsby';
 import { StaticImage } from 'gatsby-plugin-image';
 
@@ -8,7 +8,8 @@ import Layout from '../components/layout';
 import Seo from '../components/seo';
 import Table from '../components/table';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { PageMetadata, StructuredData } from '../types';
 
 const PAGE_METADATA = {
   title: 'About',
@@ -25,7 +26,7 @@ const PAGE_METADATA = {
     'technology leadership',
     'software craftsmanship',
   ],
-};
+} satisfies PageMetadata;
 
 const experience = [
   ['Silesian Solutions', 'Self-employed', 'Oct 2015 - Present', 'https://silesiansolutions.com'],
@@ -73,10 +74,10 @@ const image = {
 };
 
 const BioPage: React.FC<PageProps> = ({ location }) => {
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
   const { siteAuthor } = useSiteMetadata();
 
-  const structuredData: WithContext<WebPage> = {
+  const structuredData: StructuredData<WebPage> = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     name: PAGE_METADATA.title,

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -2,14 +2,15 @@ import type { HeadFC, PageProps } from 'gatsby';
 
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { Blog, WithContext } from 'schema-dts';
+import { Blog } from 'schema-dts';
 import { Link, graphql } from 'gatsby';
 import { GatsbyImage, getImage, IGatsbyImageData, StaticImage } from 'gatsby-plugin-image';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { PageMetadata, StructuredData } from '../types';
 
 type DataProps = {
   allMdx: {
@@ -49,11 +50,11 @@ const PAGE_METADATA = {
     'frontend development',
     'backend development',
   ],
-};
+} satisfies PageMetadata;
 
 const BlogIndex: React.FC<PageProps<DataProps>> = ({ data, location }) => {
   const { siteAuthor } = useSiteMetadata();
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
   const posts = data?.allMdx.nodes;
 
   if (posts.length === 0) {
@@ -64,7 +65,7 @@ const BlogIndex: React.FC<PageProps<DataProps>> = ({ data, location }) => {
     );
   }
 
-  const structuredData: WithContext<Blog> = {
+  const structuredData: StructuredData<Blog> = {
     '@context': 'https://schema.org',
     '@type': 'Blog',
     name: PAGE_METADATA.title,

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,12 +1,13 @@
 import type { HeadFC, PageProps } from 'gatsby';
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { WithContext, WebPage } from 'schema-dts';
+import { WebPage } from 'schema-dts';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { PageMetadata, StructuredData } from '../types';
 
 const PAGE_METADATA = {
   title: 'Contact',
@@ -22,13 +23,13 @@ const PAGE_METADATA = {
     'AI integration',
     'cybersecurity consulting',
   ],
-};
+} satisfies PageMetadata;
 
 const ContactPage: React.FC<PageProps> = ({ location }) => {
   const { siteAuthor, siteSocial } = useSiteMetadata();
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
 
-  const structuredData: WithContext<WebPage> = {
+  const structuredData: StructuredData<WebPage> = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     name: PAGE_METADATA.title,

--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -1,13 +1,14 @@
 import type { HeadFC, PageProps } from 'gatsby';
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { WithContext, CollectionPage } from 'schema-dts';
+import { CollectionPage } from 'schema-dts';
 import { graphql } from 'gatsby';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
 import Table from '../components/table';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { PageMetadata, StructuredData } from '../types';
 
 type FileNode = {
   name: string;
@@ -198,7 +199,7 @@ const PAGE_METADATA = {
     'educational materials',
     'tech conference presentations',
   ],
-};
+} satisfies PageMetadata;
 
 const PresentationsPage: React.FC<PageProps<DataType>> = ({ data, location }) => {
   const [showHidden, setShowHidden] = React.useState(false);
@@ -218,9 +219,9 @@ const PresentationsPage: React.FC<PageProps<DataType>> = ({ data, location }) =>
     };
   }, []);
 
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
 
-  const structuredData: WithContext<CollectionPage> = {
+  const structuredData: StructuredData<CollectionPage> = {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: PAGE_METADATA.title,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,12 @@
 import type { HeadFC, PageProps } from 'gatsby';
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { WithContext, WebPage } from 'schema-dts';
+import { WebPage } from 'schema-dts';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { PageMetadata, StructuredData } from '../types';
 
 const PAGE_METADATA = {
   title: 'Home',
@@ -21,12 +22,12 @@ const PAGE_METADATA = {
     'technology blog',
     'full-stack development',
   ],
-};
+} satisfies PageMetadata;
 
 const BlogIndex: React.FC<PageProps> = ({ location }) => {
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
 
-  const structuredData: WithContext<WebPage> = {
+  const structuredData: StructuredData<WebPage> = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     name: PAGE_METADATA.title,

--- a/src/pages/metadata.tsx
+++ b/src/pages/metadata.tsx
@@ -1,13 +1,14 @@
 import type { HeadFC, PageProps } from 'gatsby';
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { WithContext, CollectionPage } from 'schema-dts';
+import { CollectionPage } from 'schema-dts';
 import { graphql, Link } from 'gatsby';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
 import Table from '../components/table';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { PageMetadata, StructuredData } from '../types';
 
 type DataType = {
   nonBlogPages: { pageCount: number; pagePaths: string[] };
@@ -65,12 +66,12 @@ const PAGE_METADATA = {
     'technical details',
     'website architecture',
   ],
-};
+} satisfies PageMetadata;
 
 const MetadataPage: React.FC<PageProps<DataType>> = ({ data, location }) => {
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
 
-  const structuredData: WithContext<CollectionPage> = {
+  const structuredData: StructuredData<CollectionPage> = {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: PAGE_METADATA.title,

--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -2,12 +2,13 @@ import type { HeadFC, PageProps } from 'gatsby';
 import { StaticImage } from 'gatsby-plugin-image';
 import * as React from 'react';
 import { JsonLd } from 'react-schemaorg';
-import { WithContext, WebPage, CollectionPage } from 'schema-dts';
+import { WebPage, CollectionPage } from 'schema-dts';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
 import Table from '../components/table';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { PageMetadata, StructuredData } from '../types';
 import MermaidDiagram from '../components/mermaid-diagram';
 
 type SetupItem = [type: string, name: string, link?: string, details?: string];
@@ -102,7 +103,7 @@ const PAGE_METADATA = {
     'tech setup',
     'software engineer workspace',
   ],
-};
+} satisfies PageMetadata;
 
 const setupDiagram = `graph TD
   subgraph PrimaryStation ["Primary Device Station"]
@@ -145,9 +146,9 @@ const setupDiagram = `graph TD
 `;
 
 const SetupPage: React.FC<PageProps> = ({ location }) => {
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
 
-  const structuredData: WithContext<CollectionPage> = {
+  const structuredData: StructuredData<CollectionPage> = {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: PAGE_METADATA.title,

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { Link, graphql, PageProps, HeadProps } from 'gatsby';
 import { GatsbyImage, getImage, IGatsbyImageData } from 'gatsby-plugin-image';
 import { JsonLd } from 'react-schemaorg';
-import { WithContext, BlogPosting } from 'schema-dts';
+import { BlogPosting } from 'schema-dts';
 
 import Layout from '../components/layout';
 import Seo from '../components/seo';
 import ErrorBoundary from '../components/error-boundary';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-import { useStructuredData } from '../hooks/use-structured-data';
+import { STRUCTURED_DATA } from '../constants/structured-data';
+import type { StructuredData } from '../types';
 
 type PostNode = {
   frontmatter: {
@@ -36,12 +37,12 @@ type Data = {
 
 const BlogPostTemplate: React.FC<PageProps<Data>> = ({ data, location, children }) => {
   const { siteAuthor } = useSiteMetadata();
-  const { person } = useStructuredData();
+  const { person } = STRUCTURED_DATA;
   const { previous, next, mdx: post } = data;
 
   const img = getImage(post.frontmatter.featuredImg?.childImageSharp?.gatsbyImageData || null);
 
-  const structuredData: WithContext<BlogPosting> = {
+  const structuredData: StructuredData<BlogPosting> = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     headline: post.frontmatter.title,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export type { PageMetadata } from './page-metadata';
+export type { PersonStructuredData, StructuredData } from './structured-data';

--- a/src/types/page-metadata.ts
+++ b/src/types/page-metadata.ts
@@ -1,0 +1,9 @@
+/**
+ * Shape of a page's local `PAGE_METADATA` constant. Values stay co-located with
+ * each page for readability; this type only shares their structure.
+ */
+export type PageMetadata = {
+  title: string;
+  description: string;
+  keywords?: string[];
+};

--- a/src/types/structured-data.ts
+++ b/src/types/structured-data.ts
@@ -1,0 +1,11 @@
+import type { Person, Thing, WithContext } from 'schema-dts';
+
+/**
+ * A schema.org entity serialized as JSON-LD, including the `@context` field.
+ * Thin alias over schema-dts' `WithContext` so page-level annotations stay
+ * consistent and pages don't each reach for `WithContext` directly.
+ */
+export type StructuredData<T extends Thing> = WithContext<T>;
+
+/** Shared person entity reused across pages as `author` / `mainEntity`. */
+export type PersonStructuredData = StructuredData<Person>;


### PR DESCRIPTION
- Remove src/hooks/use-structured-data.tsx (returned a constant, not a hook)
  and import STRUCTURED_DATA directly where the person entity is used.
- Add src/types with PageMetadata and StructuredData<T>/PersonStructuredData
  aliases, replacing repeated WithContext<...> usage and the
  { person: WithContext<Person> } cast.
- Annotate each page's PAGE_METADATA with satisfies PageMetadata.

JSON-LD output verified byte-for-byte identical before/after.