### PR TITLE
ci: add build-output, link, lighthouse and dependency-review gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,23 @@ updates:
     ignore:
       # Pinned to 0.13.3 for gatsby-remark-katex compatibility — do not bump.
       - dependency-name: 'katex'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '03:00'
+      timezone: 'Europe/Warsaw'
+    open-pull-requests-limit: 1
+    assignees:
+      - 'dawidrylko'
+    rebase-strategy: 'auto'
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'
+    groups:
+      all-actions:
+        applies-to: version-updates
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ defaults:
     shell: bash
 
 jobs:
-  check:
-    name: Check
+  # Source-level static analysis. No build — these never need the artifact.
+  static:
+    name: Static checks
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         check: ['type:check', 'format:check', 'lint:check']
-        node: ['24']
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,22 +32,21 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run Check
+      - name: Run ${{ matrix.check }}
         run: pnpm run ${{ matrix.check }}
 
-      - name: Run build
-        run: pnpm run build
-
-  accessibility:
-    name: Accessibility
+  # Design-token contrast (WCAG AA) for both light and dark themes. Pure static
+  # palette check — zero deps, no build — so it stays independent of the
+  # rendered-page audit in the lighthouse job.
+  contrast:
+    name: Contrast (WCAG AA)
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +54,143 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
 
-      - name: Audit design-token contrast (WCAG AA)
+      - name: Audit design-token contrast
         run: node helpers/a11y-contrast/check-contrast.mjs
+
+  # Newly introduced vulnerable or incompatibly-licensed dependencies are
+  # blocked at the PR that adds them.
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+  # Single production build. Owns "does it compile and build" (incl. the zod
+  # frontmatter validation in gatsby-node) and produces the artifact every
+  # downstream job reuses — so the build is never duplicated.
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Upload build output
+        uses: actions/upload-artifact@v4
+        with:
+          name: public
+          path: public
+          retention-days: 1
+
+  # The build-output contract: required artifacts (RSS, sitemap, manifest, core
+  # pages) and social-share meta exist and are well-formed.
+  build-contract:
+    name: Build-output contract
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download build output
+        uses: actions/download-artifact@v4
+        with:
+          name: public
+          path: public
+
+      - name: Verify build-output contract
+        run: node helpers/ci/check-build-output.mjs
+
+  # Internal link integrity across the built site (catches broken links and
+  # broken redirects). External URLs are skipped to keep the gate deterministic.
+  links:
+    name: Link check
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download build output
+        uses: actions/download-artifact@v4
+        with:
+          name: public
+          path: public
+
+      - name: Check internal links
+        run: pnpm dlx linkinator@6.1.2 public --recurse --skip "^https?://(?!localhost)"
+
+  # Rendered-page audit (Lighthouse) of the app-owned pages: accessibility and
+  # SEO are gated; performance and best-practices are advisory. ubuntu-latest
+  # ships Chrome, which Lighthouse auto-detects.
+  lighthouse:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download build output
+        uses: actions/download-artifact@v4
+        with:
+          name: public
+          path: public
+
+      - name: Serve build output
+        run: |
+          pnpm dlx http-server@14.1.1 public -p 9000 -s &
+          npx --yes wait-on@8.0.1 http://localhost:9000/ --timeout 30000
+
+      - name: Run Lighthouse CI
+        run: pnpm dlx @lhci/cli@0.15.1 autorun --config=lighthouserc.cjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: Continuous Integration
 on:
   pull_request:
 
+# Least-privilege default for GITHUB_TOKEN across all jobs; none of them write
+# to the repo (dependency-review only needs to read the dependency graph).
+permissions:
+  contents: read
+
 concurrency:
   group: 'ci-${{ github.event.pull_request.number }}'
   cancel-in-progress: true

--- a/helpers/a11y-contrast/check-contrast.mjs
+++ b/helpers/a11y-contrast/check-contrast.mjs
@@ -2,9 +2,11 @@
 /**
  * WCAG 2.1 contrast audit for the design tokens in src/styles/main.css.
  *
- * Parses the `--color-*` custom properties from :root and verifies that every
+ * Parses the `--color-*` custom properties and verifies that every
  * foreground/background pair actually used for text in the UI meets the
- * WCAG AA threshold of 4.5:1 for normal-size text.
+ * WCAG AA threshold of 4.5:1 for normal-size text. Both themes are audited:
+ * the light `:root` tokens and the dark-mode overrides inside the
+ * `@media (prefers-color-scheme: dark)` block.
  *
  * Runs with zero dependencies so it can act as a fast CI gate without a
  * browser or build step. Exits non-zero when any pair fails.
@@ -19,20 +21,41 @@ const CSS_PATH = resolve(__dirname, '../../src/styles/main.css');
 
 const AA_NORMAL = 4.5; // normal-size text
 
-/** Parse `--color-*: #rrggbb;` declarations from the :root block. */
-function parseColorTokens(css) {
+/** Parse `--color-*: #rrggbb;` declarations out of a CSS block body. */
+function parseColorBlock(blockBody) {
+  const tokens = {};
+  const re = /--(color-[\w-]+)\s*:\s*([^;]+);/g;
+  let match;
+  while ((match = re.exec(blockBody)) !== null) {
+    tokens[match[1]] = match[2].trim();
+  }
+  return tokens;
+}
+
+/** Light tokens from the first top-level `:root` block. */
+function parseLightTokens(css) {
   const rootMatch = css.match(/:root\s*\{([^}]*)\}/);
   if (!rootMatch) {
     throw new Error('Could not find :root block in main.css');
   }
+  return parseColorBlock(rootMatch[1]);
+}
 
-  const tokens = {};
-  const re = /--(color-[\w-]+)\s*:\s*([^;]+);/g;
-  let match;
-  while ((match = re.exec(rootMatch[1])) !== null) {
-    tokens[match[1]] = match[2].trim();
+/**
+ * Dark tokens: the `:root` overrides nested in the prefers-color-scheme: dark
+ * media query, merged on top of the light tokens (the dark block only
+ * overrides colors, so unlisted tokens inherit their light values).
+ */
+function parseDarkTokens(css, lightTokens) {
+  const darkMedia = css.match(/@media\s*\(prefers-color-scheme:\s*dark\)\s*\{([\s\S]*?\}\s*)\}/);
+  if (!darkMedia) {
+    throw new Error('Could not find @media (prefers-color-scheme: dark) block in main.css');
   }
-  return tokens;
+  const rootMatch = darkMedia[1].match(/:root\s*\{([^}]*)\}/);
+  if (!rootMatch) {
+    throw new Error('Could not find :root override inside the dark-mode media block');
+  }
+  return { ...lightTokens, ...parseColorBlock(rootMatch[1]) };
 }
 
 const NAMED_COLORS = { white: '#ffffff', black: '#000000' };
@@ -69,100 +92,66 @@ function contrastRatio(a, b) {
   return (hi + 0.05) / (lo + 0.05);
 }
 
-async function main() {
-  const css = await readFile(CSS_PATH, 'utf8');
-  const tokens = parseColorTokens(css);
+/**
+ * Foreground/background pairs as actually rendered in the UI, expressed in
+ * terms of tokens so the exact same set is checked in both themes. The page
+ * background is the --color-background token (body uses it in both themes).
+ *
+ * --color-accent is intentionally excluded as a text foreground: it is used
+ * for decorative dividers (hr, table row separators, even-row shading),
+ * exempt from WCAG 1.4.11, and for the deliberately low-contrast "Metadata"
+ * easter-egg link in the footer.
+ */
+function buildPairs(t) {
+  const bg = t('color-background');
+  return [
+    { label: 'body text on page', fg: t('color-text'), bg },
+    { label: 'muted text on page', fg: t('color-text-light'), bg },
+    { label: 'heading on page', fg: t('color-heading'), bg },
+    { label: 'h1 heading on page', fg: t('color-heading-black'), bg },
+    { label: 'link (primary) on page', fg: t('color-primary'), bg },
+    { label: 'table header text (on primary)', fg: t('color-on-primary'), bg: t('color-primary') },
+    { label: 'text on accent row/active crumb', fg: t('color-text'), bg: t('color-accent') },
+    { label: 'link on accent (crumb hover)', fg: t('color-primary'), bg: t('color-accent') },
+    { label: 'muted text on accent', fg: t('color-text-light'), bg: t('color-accent') },
+  ];
+}
 
-  // Page background is the default white (body sets no background-color).
-  const WHITE = '#ffffff';
-  const t = name => {
-    const value = tokens[name];
-    if (!value) throw new Error(`Missing token --${name} in main.css`);
+function auditTheme(name, tokens) {
+  const t = key => {
+    const value = tokens[key];
+    if (!value) throw new Error(`Missing token --${key} in main.css`);
     return value;
   };
 
-  // Foreground/background pairs as actually rendered in the UI.
-  const pairs = [
-    {
-      label: 'body text on page',
-      fg: t('color-text'),
-      bg: WHITE,
-      min: AA_NORMAL,
-    },
-    {
-      label: 'muted text on page',
-      fg: t('color-text-light'),
-      bg: WHITE,
-      min: AA_NORMAL,
-    },
-    {
-      label: 'heading on page',
-      fg: t('color-heading'),
-      bg: WHITE,
-      min: AA_NORMAL,
-    },
-    {
-      label: 'h1 heading on page',
-      fg: t('color-heading-black'),
-      bg: WHITE,
-      min: AA_NORMAL,
-    },
-    {
-      label: 'link (primary) on page',
-      fg: t('color-primary'),
-      bg: WHITE,
-      min: AA_NORMAL,
-    },
-    {
-      label: 'table header text (white on primary)',
-      fg: WHITE,
-      bg: t('color-primary'),
-      min: AA_NORMAL,
-    },
-    {
-      label: 'text on accent row/active crumb',
-      fg: t('color-text'),
-      bg: t('color-accent'),
-      min: AA_NORMAL,
-    },
-    {
-      label: 'link on accent (crumb hover)',
-      fg: t('color-primary'),
-      bg: t('color-accent'),
-      min: AA_NORMAL,
-    },
-    {
-      label: 'muted text on accent',
-      fg: t('color-text-light'),
-      bg: t('color-accent'),
-      min: AA_NORMAL,
-    },
-  ];
-
-  // --color-accent is intentionally excluded as a text foreground: it is used
-  // for decorative dividers (hr, table row separators, even-row shading),
-  // exempt from WCAG 1.4.11, and for the deliberately low-contrast "Metadata"
-  // easter-egg link in the footer.
-
   let failed = 0;
-  console.log('WCAG AA contrast audit (src/styles/main.css)\n');
-  for (const { label, fg, bg, min } of pairs) {
+  console.log(`${name} theme:`);
+  for (const { label, fg, bg } of buildPairs(t)) {
     const ratio = contrastRatio(fg, bg);
-    const pass = ratio >= min;
+    const pass = ratio >= AA_NORMAL;
     if (!pass) failed += 1;
-    const mark = pass ? '✓' : '✗';
     console.log(
-      `  ${mark} ${label}: ${ratio.toFixed(2)}:1 ` +
-        `(${fg} on ${bg}, needs ${min.toFixed(1)}:1)`,
+      `  ${pass ? '✓' : '✗'} ${label}: ${ratio.toFixed(2)}:1 ` +
+        `(${fg} on ${bg}, needs ${AA_NORMAL.toFixed(1)}:1)`,
     );
   }
-
   console.log('');
+  return failed;
+}
+
+async function main() {
+  const css = await readFile(CSS_PATH, 'utf8');
+  const lightTokens = parseLightTokens(css);
+  const darkTokens = parseDarkTokens(css, lightTokens);
+
+  console.log('WCAG AA contrast audit (src/styles/main.css)\n');
+  const failed = auditTheme('Light', lightTokens) + auditTheme('Dark', darkTokens);
+
   if (failed > 0) {
     console.error(`Contrast audit failed: ${failed} pair(s) below WCAG AA.`);
     process.exit(1);
   }
-  console.log('All token pairs pass WCAG AA.');
+  console.log('All token pairs pass WCAG AA in both themes.');
 }
 
 main().catch(err => {

--- a/helpers/ci/README.md
+++ b/helpers/ci/README.md
@@ -1,0 +1,26 @@
+# helpers/ci
+
+Zero-dependency CI helpers that run against the build output, not the source.
+
+## `check-build-output.mjs`
+
+Asserts the build-output contract on `public/` after `pnpm build`:
+
+- core pages (`index.html`, `404.html`),
+- RSS feed (`rss.xml`) with an `<atom:link rel="self">`, at least one `<item>`
+  and at least one `<enclosure>`,
+- sitemap (`sitemap-index.xml` + `sitemap-0.xml`),
+- PWA manifest (`manifest.webmanifest`) with name, colors and icons,
+- Open Graph / Twitter Card meta on rendered HTML.
+
+Run locally after a build:
+
+```bash
+pnpm build
+node helpers/ci/check-build-output.mjs
+```
+
+Exits non-zero and lists every problem when the contract is violated. In CI it
+runs in the `build-contract` job against the shared build artifact, so it never
+triggers its own build. Rendered-page audits (Lighthouse) and link integrity
+(linkinator) live in separate jobs to keep responsibilities from overlapping.

--- a/helpers/ci/check-build-output.mjs
+++ b/helpers/ci/check-build-output.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Build-output contract for the Gatsby production build (public/).
+ *
+ * Asserts that the artifacts the site depends on for SEO and distribution are
+ * actually emitted and well-formed. This is a fast, zero-dependency smoke test
+ * that runs in CI against the uploaded build artifact — it does NOT rebuild,
+ * so it never duplicates the build job's responsibility. Its job is purely the
+ * "what the build must contain" contract:
+ *
+ *   - core pages (index, 404)
+ *   - RSS feed (with an <atom:link rel="self"> and at least one <item>)
+ *   - sitemap (index + first shard)
+ *   - PWA manifest (valid JSON with name, colors and at least one icon)
+ *   - Open Graph / Twitter Card meta on rendered HTML
+ *
+ * Runtime page audits (Lighthouse) and link integrity (linkinator) live in
+ * separate CI jobs; this file deliberately stays at the file-contract layer.
+ *
+ * Exits non-zero on the first contract that fails, listing every problem found.
+ */
+
+import { readFile, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PUBLIC_DIR = resolve(__dirname, '../../public');
+
+const problems = [];
+const fail = msg => problems.push(msg);
+
+async function exists(relPath) {
+  try {
+    await access(join(PUBLIC_DIR, relPath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function read(relPath) {
+  return readFile(join(PUBLIC_DIR, relPath), 'utf8');
+}
+
+/** All these files must be present in the build output. */
+async function checkRequiredFiles() {
+  const required = [
+    'index.html',
+    '404.html',
+    'rss.xml',
+    'sitemap-index.xml',
+    'sitemap-0.xml',
+    'manifest.webmanifest',
+  ];
+  for (const file of required) {
+    if (!(await exists(file))) {
+      fail(`missing required artifact: public/${file}`);
+    }
+  }
+}
+
+async function checkRss() {
+  if (!(await exists('rss.xml'))) return;
+  const rss = await read('rss.xml');
+  if (!/<item>/.test(rss)) {
+    fail('rss.xml contains no <item> entries');
+  }
+  if (!/<atom:link[^>]*rel="self"/.test(rss)) {
+    fail('rss.xml is missing its <atom:link rel="self"> element');
+  }
+  if (!/<enclosure\b/.test(rss)) {
+    fail('rss.xml has no <enclosure> — featured-image enclosures regressed');
+  }
+}
+
+async function checkManifest() {
+  if (!(await exists('manifest.webmanifest'))) return;
+  let manifest;
+  try {
+    manifest = JSON.parse(await read('manifest.webmanifest'));
+  } catch (err) {
+    fail(`manifest.webmanifest is not valid JSON: ${err.message}`);
+    return;
+  }
+  if (!manifest.name) fail('manifest.webmanifest is missing "name"');
+  if (!manifest.theme_color) fail('manifest.webmanifest is missing "theme_color"');
+  if (!manifest.background_color) fail('manifest.webmanifest is missing "background_color"');
+  if (!Array.isArray(manifest.icons) || manifest.icons.length === 0) {
+    fail('manifest.webmanifest has no icons');
+  }
+}
+
+/** Social-share meta must survive on rendered HTML (Open Graph + Twitter). */
+async function checkSocialMeta() {
+  const requiredOg = ['og:title', 'og:description', 'og:image', 'og:url', 'og:type'];
+  const requiredTwitter = ['twitter:card', 'twitter:title', 'twitter:image'];
+  const pages = ['index.html', join('blog', 'index.html')];
+
+  for (const page of pages) {
+    if (!(await exists(page))) {
+      fail(`cannot check social meta: public/${page} is missing`);
+      continue;
+    }
+    const html = await read(page);
+    for (const prop of requiredOg) {
+      if (!new RegExp(`property="${prop}"`).test(html)) {
+        fail(`public/${page} is missing Open Graph meta "${prop}"`);
+      }
+    }
+    for (const name of requiredTwitter) {
+      if (!new RegExp(`name="${name}"`).test(html)) {
+        fail(`public/${page} is missing Twitter Card meta "${name}"`);
+      }
+    }
+  }
+}
+
+async function main() {
+  if (!(await exists('.'))) {
+    console.error(`Build output not found at ${PUBLIC_DIR}. Run "pnpm build" first.`);
+    process.exit(1);
+  }
+
+  await checkRequiredFiles();
+  await checkRss();
+  await checkManifest();
+  await checkSocialMeta();
+
+  console.log('Build-output contract (public/)\n');
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(`  ✗ ${problem}`);
+    console.error(`\nBuild-output contract failed: ${problems.length} problem(s).`);
+    process.exit(1);
+  }
+  console.log('  ✓ core pages, RSS, sitemap, manifest and social meta all present.');
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -23,7 +23,6 @@ module.exports = {
         'http://localhost:9000/contact/',
         'http://localhost:9000/setup/',
         'http://localhost:9000/metadata/',
-        'http://localhost:9000/404.html',
       ],
       numberOfRuns: 1,
       settings: {

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -1,0 +1,42 @@
+/**
+ * Lighthouse CI configuration.
+ *
+ * Runs against the already-built static output (public/) served by a local
+ * static server, so it never rebuilds — the build job owns that. It audits the
+ * rendered, app-owned pages (no blog posts: those are content) for runtime
+ * regressions that static analysis cannot see.
+ *
+ * Responsibility split (no overlap with other CI jobs):
+ *   - accessibility/seo are gated as errors here at the rendered-page level;
+ *     the jsx-a11y lint and the design-token contrast gate cover the source
+ *     and palette layers respectively.
+ *   - performance/best-practices are advisory (warn) because scores vary on
+ *     shared CI runners; they still surface meaningful drops in review.
+ */
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        'http://localhost:9000/',
+        'http://localhost:9000/blog/',
+        'http://localhost:9000/bio/',
+        'http://localhost:9000/contact/',
+        'http://localhost:9000/setup/',
+        'http://localhost:9000/metadata/',
+        'http://localhost:9000/404.html',
+      ],
+      numberOfRuns: 1,
+      settings: {
+        chromeFlags: '--no-sandbox',
+      },
+    },
+    assert: {
+      assertions: {
+        'categories:accessibility': ['error', { minScore: 0.95 }],
+        'categories:seo': ['error', { minScore: 0.95 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:performance': ['warn', { minScore: 0.8 }],
+      },
+    },
+  },
+};


### PR DESCRIPTION
Harden CI to guard against regressions ahead of a framework migration,
keeping each job to a single responsibility and building only once.

- split static checks from the build; the build now runs a single time and
  every downstream job reuses its uploaded artifact (was: build re-run per
  matrix check)
- add a zero-dep build-output contract (helpers/ci/check-build-output.mjs):
  RSS/sitemap/manifest/core pages plus Open Graph and Twitter Card meta
- add internal link integrity (linkinator), skipping external URLs to stay
  deterministic
- add a rendered-page Lighthouse audit of the app-owned pages: accessibility
  and SEO gated, performance and best-practices advisory
- add dependency-review on PRs (fail on high severity)
- extend the contrast gate to audit the dark-mode tokens as well as light,
  using the --color-background/--color-on-primary tokens
- track github-actions versions in Dependabot