### PR TITLE
fix(blog): hide pagination during search, surface tags, tidy nav

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -34,7 +34,7 @@ function buildCrumbs(): Crumb[] {
   }
 
   const pathMap = menu.reduce<Record<string, string>>((acc, item) => {
-    acc[item.url.replace('/', '')] = item.name;
+    acc[item.url.replace(/\//g, '')] = item.name;
     return acc;
   }, {});
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -29,7 +29,7 @@ export async function getStaticPaths() {
 
 const { post, previous, next } = Astro.props;
 const { Content } = await render(post);
-const { title, description, date, featuredImg, featuredImgAlt } = post.data;
+const { title, description, date, tags, featuredImg, featuredImgAlt } = post.data;
 
 const dateFormatted = date.toLocaleDateString('pl-PL', { year: 'numeric', month: 'long', day: '2-digit' });
 const { person } = STRUCTURED_DATA;
@@ -80,6 +80,17 @@ const structuredData = {
     <section>
       <Content />
     </section>
+    <ul class="tags" aria-label="Tagi">
+      {
+        tags.map(tag => (
+          <li>
+            <a class="tag" href={`/blog/?q=${encodeURIComponent(tag)}`}>
+              #{tag}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
   </article>
 
   <nav class="blog-post-nav">

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -138,6 +138,15 @@ const structuredData = {
               )}
               <p set:html={descriptionHtml} />
             </section>
+            <ul class="tags" aria-label="Tagi">
+              {post.data.tags.map(tag => (
+                <li>
+                  <a class="tag" href={`/blog/?q=${encodeURIComponent(tag)}`} data-tag={tag}>
+                    #{tag}
+                  </a>
+                </li>
+              ))}
+            </ul>
           </article>
         </li>
       ))
@@ -148,12 +157,12 @@ const structuredData = {
     page.lastPage > 1 && (
       <nav class="pagination" aria-label="Nawigacja po stronach bloga" id="blog-pagination">
         {page.url.prev ? (
-          <a class="pagination-edge" href={page.url.prev} rel="prev">
-            ← <span>Poprzednia</span>
+          <a class="pagination-edge" href={page.url.prev} rel="prev" aria-label="Poprzednia strona">
+            ←
           </a>
         ) : (
           <span class="pagination-edge is-disabled" aria-hidden="true">
-            ← <span>Poprzednia</span>
+            ←
           </span>
         )}
 
@@ -174,12 +183,12 @@ const structuredData = {
         </ol>
 
         {page.url.next ? (
-          <a class="pagination-edge" href={page.url.next} rel="next">
-            <span>Następna</span> →
+          <a class="pagination-edge" href={page.url.next} rel="next" aria-label="Następna strona">
+            →
           </a>
         ) : (
           <span class="pagination-edge is-disabled" aria-hidden="true">
-            <span>Następna</span> →
+            →
           </span>
         )}
       </nav>
@@ -273,13 +282,40 @@ const structuredData = {
         section.appendChild(p);
 
         article.append(header, section);
+
+        if (item.tags.length) {
+          const tags = document.createElement('ul');
+          tags.className = 'tags';
+          tags.setAttribute('aria-label', 'Tagi');
+          for (const tag of item.tags) {
+            const tagLi = document.createElement('li');
+            const tagLink = document.createElement('a');
+            tagLink.className = 'tag';
+            tagLink.href = `/blog/?q=${encodeURIComponent(tag)}`;
+            tagLink.dataset.tag = tag;
+            tagLink.textContent = `#${tag}`;
+            tagLi.appendChild(tagLink);
+            tags.appendChild(tagLi);
+          }
+          article.appendChild(tags);
+        }
+
         li.appendChild(article);
         results.appendChild(li);
       }
     };
 
+    // Keep the URL in sync so a search is shareable and survives a reload.
+    const syncUrl = (query: string) => {
+      const url = new URL(location.href);
+      if (query) url.searchParams.set('q', query);
+      else url.searchParams.delete('q');
+      history.replaceState(null, '', url);
+    };
+
     const search = async (query: string) => {
       const q = query.trim();
+      syncUrl(q);
       if (!q) {
         results.hidden = true;
         results.replaceChildren();
@@ -311,5 +347,25 @@ const structuredData = {
       clearTimeout(debounce);
       debounce = setTimeout(() => void search(input.value), 120);
     });
+
+    // Tag chips (in the list and in search results) drive the same search box
+    // instead of reloading the page.
+    document.addEventListener('click', event => {
+      const target = event.target as HTMLElement;
+      const tagLink = target.closest<HTMLElement>('[data-tag]');
+      if (!tagLink) return;
+      event.preventDefault();
+      const tag = tagLink.dataset.tag ?? '';
+      input.value = tag;
+      void search(tag);
+      input.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    });
+
+    // Honour ?q= on load so tag links from a post (and shared URLs) run a search.
+    const initialQuery = new URLSearchParams(location.search).get('q');
+    if (initialQuery) {
+      input.value = initialQuery;
+      void search(initialQuery);
+    }
   }
 </script>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -614,7 +614,46 @@ blockquote {
   min-height: 1.5em;
 }
 
+/* Tags */
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin: var(--spacing-4) var(--spacing-0) var(--spacing-0);
+  padding: var(--spacing-0);
+  list-style: none;
+}
+
+.tags li {
+  margin: var(--spacing-0);
+  list-style: none;
+}
+
+.tag {
+  display: inline-block;
+  font-family: var(--font-heading);
+  font-size: var(--fontSize-0);
+  line-height: 1.2;
+  padding: var(--spacing-1) var(--spacing-2);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--spacing-1);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.tag:hover,
+.tag:focus {
+  background-color: var(--color-accent);
+}
+
 /* Pagination */
+
+/* Beats the [hidden] reset's display:none being overridden by .pagination's
+   display:flex, so the client-side search can fully hide pagination. */
+.pagination[hidden] {
+  display: none;
+}
 
 .pagination {
   display: flex;


### PR DESCRIPTION
- Hide pagination while searching: .pagination[hidden] now wins over the
  display:flex rule that previously kept it visible and misleading.
- Show post tags on the blog list, in search results and on posts; tag
  chips run a client-side search (or ?q= on navigation from a post).
- Keep the proper 'Blog PL' label on the page 2/3 breadcrumb by stripping
  all slashes when matching menu segments.
- Replace the 'Poprzednia'/'Nastepna' pagination labels with arrows plus
  accessible aria-labels.