### PR TITLE
fix: restore files listing, hidden-variant shortcut and setup diagram overflow

### DIFF
--- a/helpers/ci/check-astro-build-output.mjs
+++ b/helpers/ci/check-astro-build-output.mjs
@@ -12,6 +12,9 @@
  *   - blog-list thumbnails render at a bounded (600px) size, not full-res
  *   - post-body list markers stay outside (not dropped onto their own line)
  *   - breadcrumbs truncate on one line (no horizontal-scroll fallback)
+ *   - the /files/ page lists presentations (static/files is read from disk)
+ *   - the /files/ cmd/ctrl+shift+. hidden-variant toggle ships and is wired up
+ *   - the /setup/ Mermaid diagram cannot push page-level horizontal scroll
  *
  * Exits non-zero listing every contract that fails.
  */
@@ -118,6 +121,53 @@ async function checkDemoHydration() {
   }
 }
 
+async function checkFilesPage() {
+  if (!(await exists('files/index.html'))) {
+    fail('cannot check files page: files/index.html missing');
+    return;
+  }
+  const html = await read('files/index.html');
+  // The page reads static/files from disk at build time. A wrong base path
+  // (the old Gatsby '../static/files') resolves outside the repo and renders an
+  // empty table — assert at least one real download link made it into the page.
+  if (!/href="\/files\/[^"]+"/.test(html)) {
+    fail('files page lists no downloadable files (static/files not read — check the base path)');
+  }
+  if (!/download="/.test(html)) {
+    fail('files page has no download links (presentation rows did not render)');
+  }
+}
+
+async function checkFilesHiddenToggle() {
+  if (!(await exists('files/index.html'))) {
+    fail('cannot check files toggle: files/index.html missing');
+    return;
+  }
+  const html = await read('files/index.html');
+  // Hidden Keynote/PowerPoint variants must be in the DOM (CSS-hidden), and the
+  // cmd/ctrl+shift+. keyboard handler must ship inline to reveal them.
+  if (!/is-hidden-variant/.test(html)) {
+    fail('files page is missing hidden Keynote/PowerPoint variants (cmd+shift+. has nothing to reveal)');
+  }
+  if (!/show-hidden-variants/.test(html) || !/shiftKey/.test(html) || !/metaKey/.test(html)) {
+    fail('files page cmd/ctrl+shift+. toggle script did not ship inline');
+  }
+}
+
+async function checkMermaidOverflow(css) {
+  // The Mermaid SVG is a flex child; without min-width: 0 (and an overflow
+  // guard on the container) a wide diagram overruns max-width: 100% and pushes
+  // page-level horizontal scroll on phones (the /setup/ regression).
+  const container = css.match(/\.mermaid-diagram\{([^}]*)\}/);
+  const svg = css.match(/\.mermaid-diagram svg\{([^}]*)\}/);
+  if (!container || !/overflow-x:\s*auto/.test(container[1])) {
+    fail('.mermaid-diagram is missing overflow-x: auto (diagram can push page horizontal scroll)');
+  }
+  if (!svg || !/min-width:\s*0/.test(svg[1])) {
+    fail('.mermaid-diagram svg is missing min-width: 0 (flex child can overrun max-width on mobile)');
+  }
+}
+
 async function checkBlogThumbnail() {
   if (!(await exists('blog/index.html'))) {
     fail('cannot check blog thumbnails: blog/index.html missing');
@@ -145,8 +195,11 @@ async function main() {
   await checkListMarkers(css);
   await checkBreadcrumbs(css);
   await checkSetupMermaid();
+  await checkMermaidOverflow(css);
   await checkDemoHydration();
   await checkBlogThumbnail();
+  await checkFilesPage();
+  await checkFilesHiddenToggle();
 
   console.log('Astro build-output regression contract (dist/)\n');
   if (problems.length > 0) {
@@ -154,7 +207,9 @@ async function main() {
     console.error(`\nRegression contract failed: ${problems.length} problem(s).`);
     process.exit(1);
   }
-  console.log('  ✓ code dark theme, Mermaid + demo hydration, thumbnails, list markers, breadcrumbs.');
+  console.log(
+    '  ✓ code dark theme, Mermaid hydration + overflow, demo hydration, thumbnails, list markers, breadcrumbs, files listing + toggle.',
+  );
 }
 
 main().catch(err => {

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -9,7 +9,10 @@ import { STRUCTURED_DATA } from '../data/structured-data';
 // tree from disk at build time. publicDir ('../static') serves these at /files.
 type FileNode = { name: string; extension: string; publicURL: string; size: number };
 
-const filesDir = path.resolve(process.cwd(), '../static/files');
+// publicDir is 'static' (astro.config.mjs), relative to the project root, which
+// is process.cwd() during the build. The leading '../' here was a leftover
+// Gatsby assumption that resolved outside the repo, so no files were ever read.
+const filesDir = path.resolve(process.cwd(), 'static/files');
 
 const readFilesRecursively = (dir: string, baseDir: string): FileNode[] => {
   if (!fs.existsSync(dir)) {
@@ -91,11 +94,6 @@ const getFileMetadata = (extension: string): FileConfig[] =>
     { icon: '📎', type: extension.toUpperCase(), action: 'download', hidden: false },
   ];
 
-// Phase 3 renders the default view (showHidden = false). The Gatsby
-// cmd+shift+. toggle that reveals Keynote/PowerPoint variants is an interactive
-// island deferred to a later pass.
-const showHidden = false;
-
 const grouped = groupFilesByIdentity(nodes);
 const sortedEntries = Array.from(grouped.entries()).sort(([keyA], [keyB]) => {
   const a = parseFileName(grouped.get(keyA)?.[0]?.name ?? '');
@@ -118,17 +116,18 @@ const rows = sortedEntries
         return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib);
       })
       .flatMap(file =>
-        getFileMetadata(file.extension)
-          .filter(config => !config.hidden || showHidden)
-          .map(config => ({
-            href: file.publicURL,
-            icon: config.icon,
-            action: config.action,
-            type: config.type,
-            size: formatFileSize(file.size),
-            title: parsed.title,
-            download: `${parsed.title} - Dawid Ryłko - dawidrylko.com.${file.extension}`,
-          })),
+        getFileMetadata(file.extension).map(config => ({
+          href: file.publicURL,
+          icon: config.icon,
+          action: config.action,
+          type: config.type,
+          // Keynote/PowerPoint variants are rendered but CSS-hidden by default;
+          // the cmd/ctrl+shift+. shortcut reveals them (see the inline script).
+          hidden: config.hidden,
+          size: formatFileSize(file.size),
+          title: parsed.title,
+          download: `${parsed.title} - Dawid Ryłko - dawidrylko.com.${file.extension}`,
+        })),
       );
     return {
       index: index + 1,
@@ -196,7 +195,7 @@ const structuredData = {
   <main>
     <section aria-labelledby="presentations-heading">
       <h2 id="presentations-heading">Presentations</h2>
-      <table>
+      <table class="presentations-table" data-presentations>
         <thead>
           <tr>
             <th scope="col">#</th>
@@ -221,6 +220,7 @@ const structuredData = {
                     {row.links.map(link =>
                       link.action === 'open' ? (
                         <a
+                          class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
                           href={link.href}
                           target="_blank"
                           rel="noopener noreferrer"
@@ -231,6 +231,7 @@ const structuredData = {
                         </a>
                       ) : (
                         <a
+                          class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
                           href={link.href}
                           download={link.download}
                           aria-label={`Download ${link.title} as ${link.type}`}
@@ -249,4 +250,21 @@ const structuredData = {
       </table>
     </section>
   </main>
+
+  <!-- Ported from the Gatsby files page: cmd/ctrl+shift+. toggles the hidden
+       Keynote/PowerPoint download variants. Kept as an is:inline script so the
+       behaviour lives in the page (no React island needed) and stays assertable
+       by the build-output regression contract. -->
+  <script is:inline>
+    (function () {
+      const table = document.querySelector('[data-presentations]');
+      if (!table) return;
+      document.addEventListener('keydown', function (event) {
+        if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key === '.') {
+          event.preventDefault();
+          table.classList.toggle('show-hidden-variants');
+        }
+      });
+    })();
+  </script>
 </PageLayout>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -339,6 +339,16 @@ table tr:nth-child(even) {
   background-color: var(--color-accent);
 }
 
+/* Files page: Keynote/PowerPoint download variants are hidden until the
+   cmd/ctrl+shift+. shortcut adds .show-hidden-variants to the table. */
+.presentations-table .file-link.is-hidden-variant {
+  display: none;
+}
+
+.presentations-table.show-hidden-variants .file-link.is-hidden-variant {
+  display: inline;
+}
+
 /* Link */
 
 a {
@@ -854,11 +864,18 @@ blockquote {
   display: flex;
   justify-content: center;
   margin: var(--spacing-6) 0;
+  /* Safety net: keep a wide diagram from pushing horizontal scroll onto the
+     whole page (notably on phones) — it scrolls within its own box instead. */
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .mermaid-diagram svg {
   max-width: 100%;
   height: auto;
+  /* Flex children default to min-width: auto, which would let the SVG keep its
+     intrinsic width and overrun max-width: 100% on narrow viewports. */
+  min-width: 0;
 }
 
 .mermaid-diagram-fallback {


### PR DESCRIPTION
The Gatsby → Astro migration left three regressions:

- files page read static/files via a leftover '../static/files' base path
  that resolved outside the repo, so no presentations were ever listed.
  Read from 'static/files' (publicDir, relative to the build cwd).
- the cmd/ctrl+shift+. toggle that reveals Keynote/PowerPoint download
  variants was dropped. Render the hidden variants (CSS-hidden) and wire
  the shortcut back up with an inline script.
- the /setup/ Mermaid diagram pushed page-level horizontal scroll on
  phones: as a flex child its default min-width: auto overran
  max-width: 100%. Add min-width: 0 and an overflow-x guard on the box.

Extend the build-output regression contract to lock in all three.