### PR TITLE
refactor(blog): make pagination arrows part of the page list

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -156,17 +156,18 @@ const structuredData = {
   {
     page.lastPage > 1 && (
       <nav class="pagination" aria-label="Nawigacja po stronach bloga" id="blog-pagination">
-        {page.url.prev ? (
-          <a class="pagination-edge" href={page.url.prev} rel="prev" aria-label="Poprzednia strona">
-            ←
-          </a>
-        ) : (
-          <span class="pagination-edge is-disabled" aria-hidden="true">
-            ←
-          </span>
-        )}
-
         <ol class="pagination-pages">
+          <li>
+            {page.url.prev ? (
+              <a class="pagination-edge" href={page.url.prev} rel="prev" aria-label="Poprzednia strona">
+                ←
+              </a>
+            ) : (
+              <span class="pagination-edge is-disabled" aria-hidden="true">
+                ←
+              </span>
+            )}
+          </li>
           {Array.from({ length: page.lastPage }, (_, i) => i + 1).map(n => (
             <li>
               {n === page.currentPage ? (
@@ -180,17 +181,18 @@ const structuredData = {
               )}
             </li>
           ))}
+          <li>
+            {page.url.next ? (
+              <a class="pagination-edge" href={page.url.next} rel="next" aria-label="Następna strona">
+                →
+              </a>
+            ) : (
+              <span class="pagination-edge is-disabled" aria-hidden="true">
+                →
+              </span>
+            )}
+          </li>
         </ol>
-
-        {page.url.next ? (
-          <a class="pagination-edge" href={page.url.next} rel="next" aria-label="Następna strona">
-            →
-          </a>
-        ) : (
-          <span class="pagination-edge is-disabled" aria-hidden="true">
-            →
-          </span>
-        )}
       </nav>
     )
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -666,24 +666,18 @@ blockquote {
 }
 
 .pagination {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-2) var(--spacing-4);
   margin-top: var(--spacing-10);
 }
 
 .pagination-pages {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   justify-content: center;
   gap: var(--spacing-2);
   margin: var(--spacing-0);
   padding: var(--spacing-0);
   list-style: none;
-  order: 3;
-  flex-basis: 100%;
 }
 
 .pagination-pages li {
@@ -691,8 +685,11 @@ blockquote {
   list-style: none;
 }
 
+/* Page numbers and the prev/next arrows share one button shape so the arrows
+   read as part of the pagination control rather than floating beside it. */
 .pagination-pages a,
-.pagination-pages .is-current {
+.pagination-pages .is-current,
+.pagination-edge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -705,12 +702,15 @@ blockquote {
   font-size: var(--fontSize-0);
 }
 
-.pagination-pages a {
+.pagination-pages a,
+.pagination-edge {
   color: var(--color-primary);
 }
 
 .pagination-pages a:hover,
-.pagination-pages a:focus {
+.pagination-pages a:focus,
+.pagination-edge:hover,
+.pagination-edge:focus {
   background-color: var(--color-accent);
 }
 
@@ -720,48 +720,9 @@ blockquote {
   font-weight: var(--fontWeight-bold);
 }
 
-.pagination-edge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-1);
-  min-height: 2.75rem;
-  padding: var(--spacing-1) var(--spacing-3);
-  border-radius: var(--spacing-1);
-  text-decoration: none;
-  font-family: var(--font-heading);
-  font-size: var(--fontSize-0);
-  color: var(--color-primary);
-}
-
-.pagination-edge:first-child {
-  order: 1;
-  margin-right: auto;
-}
-
-.pagination-edge:last-child {
-  order: 2;
-  margin-left: auto;
-}
-
-.pagination-edge:hover,
-.pagination-edge:focus {
-  background-color: var(--color-accent);
-}
-
 .pagination-edge.is-disabled {
   color: var(--color-text-light);
   opacity: 0.5;
-}
-
-@media screen and (min-width: 600px) {
-  .pagination-pages {
-    order: 2;
-    flex-basis: auto;
-  }
-
-  .pagination-edge:last-child {
-    order: 3;
-  }
 }
 
 /* Media queries */


### PR DESCRIPTION
## Summary

Moves the prev/next pagination arrows into the page-number list so they read as part of the pagination control rather than floating at the row edges.

- The `←`/`→` arrows are now `<li>` items inside `pagination-pages`, inline with the page numbers (`← 1 2 3 4 →`).
- Arrows and page numbers share the same button shape (size, padding, radius, hover), so the control looks unified.
- Removed the now-unused `order`/`margin: auto`/`flex-basis` rules and the responsive media query that floated the arrows to the edges.

The accessible `aria-label`s on the arrows, the `is-disabled` state and hiding the pagination during search are unchanged.

> The rest of the original branch (hide pagination during search, surface tags, breadcrumb fix) already landed on `master` via #404, so this PR now contains only the arrows refactor.

## Verification

- `pnpm type:check`, `pnpm lint:check`, `pnpm format:check` — pass
- `pnpm build` — OK; inspected rendered pagination HTML