### PR TITLE
ci: block AI attribution in commit messages and PR descriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,31 @@ jobs:
       - name: Run ${{ matrix.check }}
         run: pnpm run ${{ matrix.check }}
 
+  # Blocks AI attribution (Co-Authored-By: Claude, Claude-Session, "Generated
+  # with Claude Code", …) in commit messages and the PR title/description, per
+  # CLAUDE.md. Zero deps, no build. fetch-depth: 0 so base..head resolves.
+  attribution:
+    name: No AI attribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Check commit messages and PR title/description
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node helpers/ci/check-no-ai-attribution.mjs
+
   # Design-token contrast (WCAG AA) for both light and dark themes. Pure static
   # palette check — zero deps, no build — independent of the lighthouse audit.
   contrast:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,4 +76,5 @@ Hook uruchamia kolejno: `lint-staged` (Prettier + ESLint na staged) → `pnpm ty
 ## Git i pull requesty
 
 - Pisz commity oraz tytuły i opisy PR **po angielsku**, w formacie **Conventional Commits** (`docs:`, `feat:`, `fix:`, …).
-- **Nie dodawaj atrybucji AI** — żadnych `Co-Authored-By`, `Claude-Session` ani stopek typu „Generated with Claude Code” w commitach i opisach PR.
+- **Nie dodawaj atrybucji AI** — żadnych `Co-Authored-By`, `Claude-Session` ani stopek typu „Generated with Claude Code” w commitach i opisach PR. Pilnuje tego CI (`helpers/ci/check-no-ai-attribution.mjs`).
+- **Po zmianie zakresu pilnuj zgodności opisu z treścią** — gdy po rebase, squashu lub odrzuceniu commitów zmieni się faktyczna zawartość gałęzi, zaktualizuj tytuł i opis commita oraz PR-a, tak aby opisywały tylko to, co realnie zostaje w diffie. Nie zostawiaj opisu sprzed zmiany zakresu.

--- a/helpers/ci/README.md
+++ b/helpers/ci/README.md
@@ -24,3 +24,18 @@ Exits non-zero and lists every problem when the contract is violated. In CI it
 runs in the `build-contract` job against the shared build artifact, so it never
 triggers its own build. Rendered-page audits (Lighthouse) and link integrity
 (linkinator) live in separate jobs to keep responsibilities from overlapping.
+
+## `check-no-ai-attribution.mjs`
+
+Enforces the no-AI-attribution rule from `CLAUDE.md`: fails if a commit message
+or the PR title/description contains `Co-Authored-By: Claude`, `Claude-Session`,
+"Generated with Claude Code", a `🤖 Generated` footer, a `claude.ai/code` link,
+etc.
+
+Runs in CI in the `attribution` job on `pull_request`. The PR title and body are
+passed via env (never interpolated into a shell command); commit messages are
+read from `git log BASE_SHA..HEAD_SHA`. Run it locally against a range:
+
+```bash
+BASE_SHA=origin/master HEAD_SHA=HEAD node helpers/ci/check-no-ai-attribution.mjs
+```

--- a/helpers/ci/check-no-ai-attribution.mjs
+++ b/helpers/ci/check-no-ai-attribution.mjs
@@ -1,0 +1,62 @@
+// Blocks AI attribution in commit messages and the PR title/description, per
+// the project rule (CLAUDE.md > "Git i pull requesty"): no `Co-Authored-By`,
+// `Claude-Session` or "Generated with Claude Code" footers anywhere. Runs in CI
+// on pull_request. Zero dependencies.
+import { execSync } from 'node:child_process';
+
+const PATTERNS = [
+  /generated with .{0,40}claude/i,
+  /co-?authored-by:\s*claude/i,
+  /claude-session/i,
+  /claude\.ai\/code/i,
+  /🤖\s*generated/i,
+];
+
+const sources = [];
+
+// PR title and description are passed by the workflow via env so the body is
+// never interpolated into a shell command (avoids injection).
+for (const [label, value] of [
+  ['PR title', process.env.PR_TITLE],
+  ['PR description', process.env.PR_BODY],
+]) {
+  if (value && value.trim()) {
+    sources.push({ label, text: value });
+  }
+}
+
+// Commit messages on the PR (base..head). The workflow passes both SHAs and
+// fetches full history so the range resolves.
+const base = process.env.BASE_SHA;
+const head = process.env.HEAD_SHA;
+if (base && head) {
+  const log = execSync(`git log -z --format=%B ${base}..${head}`, { encoding: 'utf8' });
+  for (const message of log.split('\0')) {
+    if (message.trim()) {
+      sources.push({ label: 'commit message', text: message });
+    }
+  }
+}
+
+const violations = [];
+for (const { label, text } of sources) {
+  for (const pattern of PATTERNS) {
+    const match = text.match(pattern);
+    if (match) {
+      violations.push(`${label}: "${match[0].trim()}"`);
+    }
+  }
+}
+
+if (violations.length) {
+  console.error('✗ Forbidden AI attribution found:');
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  console.error(
+    '\nRemove AI attribution (Co-Authored-By, Claude-Session, "Generated with Claude Code", 🤖 footers, …) from commit messages and the PR title/description. See CLAUDE.md.',
+  );
+  process.exit(1);
+}
+
+console.log('✓ No AI attribution in commit messages or PR title/description.');


### PR DESCRIPTION
## Summary

Automates the existing CLAUDE.md rule that forbids AI attribution in git history and PR metadata. Until now the rule was only documented; this adds a CI guard that enforces it.

## Changes

- **`helpers/ci/check-no-ai-attribution.mjs`** — zero-dependency Node script that fails when a commit message or the PR title/description contains AI-attribution markers (co-author trailers, session links, generator footers and robot-emoji footers).
- **`.github/workflows/ci.yml`** — new `attribution` job on `pull_request`. The PR title and body are passed via env (never interpolated into a shell command, so no injection); commit messages are read from the base..head range with `fetch-depth: 0`.
- **`helpers/ci/README.md`** — documents the script and how to run it locally.
- **`CLAUDE.md`** — notes the CI enforcement on the no-attribution rule and adds the description-sync rule (keep commit/PR descriptions consistent with the actual diff after scope changes).

## Note

The script scans only commit messages and the PR title/body, so the exact marker strings can still live in source files (the script, README and CLAUDE.md) without tripping the check. This PR's own commit messages and description deliberately avoid the literal markers.

## Testing

- `pnpm format:check`, `pnpm lint:check`, `pnpm type:check` — all pass.
- Ran the script locally against a clean range (passes) and against a body containing a forbidden marker (fails as expected, exit 1).