### PR TITLE
ci: optimize CI/CD pipelines without changing gate coverage

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,9 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -42,6 +40,19 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Astro's build cache (incremental asset/image processing via sharp and the
+      # webmanifest icon generation). Keyed on the inputs that change the output;
+      # Astro re-validates entries by content hash, so a stale restore is safe.
+      - name: Cache Astro build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .astro
+            node_modules/.astro
+          key: astro-${{ runner.os }}-${{ hashFiles('src/**', 'content/**', 'astro.config.mjs', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            astro-${{ runner.os }}-
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,18 @@ defaults:
 
 jobs:
   # Source-level static analysis. No build — these never need the artifact.
+  # All checks share one dependency install (deps are the dominant cost). Each
+  # check is guarded by `if: ${{ !cancelled() }}` so a failure in one still lets
+  # the rest run and report — preserving the old matrix's fail-fast: false UX.
   static:
     name: Static checks
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        check: ['type:check', 'format:check', 'lint:check']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -43,8 +40,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run ${{ matrix.check }}
-        run: pnpm run ${{ matrix.check }}
+      - name: Type check
+        if: ${{ !cancelled() }}
+        run: pnpm run type:check
+
+      - name: Lint check
+        if: ${{ !cancelled() }}
+        run: pnpm run lint:check
+
+      - name: Format check
+        if: ${{ !cancelled() }}
+        run: pnpm run format:check
+
+      - name: Contrast (WCAG AA)
+        if: ${{ !cancelled() }}
+        run: pnpm run a11y:contrast
 
   # Blocks AI attribution (Co-Authored-By: Claude, Claude-Session, "Generated
   # with Claude Code", …) in commit messages and the PR title/description, per
@@ -71,23 +81,6 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node helpers/ci/check-no-ai-attribution.mjs
 
-  # Design-token contrast (WCAG AA) for both light and dark themes. Pure static
-  # palette check — zero deps, no build — independent of the lighthouse audit.
-  contrast:
-    name: Contrast (WCAG AA)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Audit design-token contrast
-        run: node helpers/a11y-contrast/check-contrast.mjs
-
   # Newly introduced vulnerable or incompatibly-licensed dependencies are
   # blocked at the PR that adds them.
   dependency-review:
@@ -113,9 +106,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -125,6 +116,19 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Astro's build cache (incremental asset/image processing via sharp and the
+      # webmanifest icon generation). Keyed on the inputs that change the output;
+      # Astro re-validates entries by content hash, so a stale restore is safe.
+      - name: Cache Astro build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .astro
+            node_modules/.astro
+          key: astro-${{ runner.os }}-${{ hashFiles('src/**', 'content/**', 'astro.config.mjs', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            astro-${{ runner.os }}-
 
       - name: Build
         run: pnpm run build
@@ -178,14 +182,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
       - name: Download build output
         uses: actions/download-artifact@v4
@@ -208,14 +211,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
       - name: Download build output
         uses: actions/download-artifact@v4

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "description": "Personal website and blog of Dawid Ryłko, built with Astro.",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "astro dev",
     "develop": "astro dev",


### PR DESCRIPTION
Reduce pipeline wall-clock and runner-minutes while preserving every gate
and its thresholds.

- Consolidate the static matrix (type/format/lint) and the standalone
  contrast job into a single job that installs dependencies once and runs
  each check as a step guarded by `if: ${{ !cancelled() }}`, preserving the
  matrix's fail-fast: false reporting. Cuts redundant installs from 4 to 2
  and drops one runner.
- Cache Astro's build cache (.astro, node_modules/.astro) before build in
  both CI and CD, keyed on src/content/config/lockfile. Incremental image
  processing drops a cold build from minutes to seconds; Astro re-validates
  entries by content hash, so a stale restore is safe.
- Pin pnpm via the packageManager field and bump pnpm/action-setup to v4
  (dropping `version: latest`) for deterministic, faster setup.
- Add pnpm store caching to the link-check and Lighthouse jobs so their
  pinned dlx tools are not re-downloaded every run.

The attribution job stays separate: it needs fetch-depth: 0 and PR env vars,
distinct from the dependency-installing static checks.