### PR TITLE
refactor: extract shared date, page-schema, link and figure helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,30 @@ jobs:
         if: ${{ !cancelled() }}
         run: pnpm run a11y:contrast
 
+  # Unit tests (Vitest) for the framework-agnostic logic in src/lib. No build —
+  # these run directly against the source.
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm run test
+
   # Blocks AI attribution (Co-Authored-By: Claude, Claude-Session, "Generated
   # with Claude Code", …) in commit messages and the PR title/description, per
   # CLAUDE.md. Zero deps, no build. fetch-depth: 0 so base..head resolves.
@@ -232,3 +256,37 @@ jobs:
 
       - name: Run Lighthouse CI
         run: pnpm dlx @lhci/cli@0.15.1 autorun --config=lighthouserc.cjs
+
+  # End-to-end and axe-core accessibility smoke tests (Playwright) against the
+  # built site served by `astro preview`. Reuses the dist/ artifact.
+  e2e:
+    name: End-to-end (Playwright)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build output
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: pnpm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: pnpm run lint:check
 
+      - name: CSS lint check
+        if: ${{ !cancelled() }}
+        run: pnpm run lint:css
+
       - name: Format check
         if: ${{ !cancelled() }}
         run: pnpm run format:check
@@ -194,6 +198,9 @@ jobs:
 
       - name: Verify rendering-regression contract
         run: node helpers/ci/check-astro-build-output.mjs
+
+      - name: Verify SEO / structured-data contract
+        run: node helpers/ci/check-seo-meta.mjs
 
   # Internal link integrity across the built site (catches broken links and
   # broken redirects). External URLs are skipped to keep the gate deterministic.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@ node_modules/
 dist/
 .astro/
 
+# Test output
+coverage/
+playwright-report/
+test-results/
+.playwright/
+
 # Draft
 draft/
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+src/styles/normalize.css

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["stylelint-config-standard"],
+  "rules": {
+    "custom-property-pattern": null,
+    "keyframes-name-pattern": null,
+    "no-descending-specificity": null
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Potrzebne przy modyfikacji `[...slug].astro`, `content.config.ts`, RSS (`rss.xml
 
 - Post to katalog `content/pl/YYYY-MM-DD--slug-po-polsku/index.mdx` (część katalogów ma też strony wtórne, np. `.../ng-help.md`).
 - Slug URL powstaje w `content.config.ts` (`generateId`: usunięcie rozszerzenia, `/index`, oraz prefiksu daty `replace(/.*--/, '')`): `2025-12-26--od-tablicy-do-mapy` → `/od-tablicy-do-mapy/`. **URL-e muszą zostać zachowane** (SEO) — pilnuje tego `helpers/ci/check-astro-url-parity.mjs`.
-- Frontmatter: `title`, `description`, `date`, `tags`, opcjonalnie `featuredImg` + `featuredImgAlt` (gdy jest `featuredImg`, `featuredImgAlt` jest wymagany — reguła w schemacie zod).
+- Frontmatter: `title`, `description`, `date`, `tags`, opcjonalnie `updatedDate` (mapuje się na `dateModified` / `article:modified_time`), `featuredImg` + `featuredImgAlt` (gdy jest `featuredImg`, `featuredImgAlt` jest wymagany — reguła w schemacie zod).
 - Renderowanie MDX: **Shiki** (kod, motyw jasny/ciemny), **KaTeX** (matematyka, `remark-math` + `rehype-katex`), **Mermaid** (diagram jako wyspa React `client:*`).
 
 ## Konwencje kodu

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,15 @@ pnpm format:check   # Prettier — sprawdzenie
 pnpm lint:fix       # ESLint — napraw
 pnpm lint:check     # ESLint — sprawdź
 pnpm a11y:contrast  # audyt kontrastu design-tokenów (WCAG AA)
+pnpm test           # testy jednostkowe (Vitest, jednorazowo)
+pnpm test:watch     # Vitest w trybie watch
+pnpm test:coverage  # Vitest + pokrycie (v8)
+pnpm test:e2e       # testy e2e + a11y (Playwright) na zbudowanym dist/
 ```
 
-Przed zatwierdzeniem zmian uruchom `pnpm type:check`, `pnpm lint:check` i `pnpm format:check`. Nie pisz ani nie uruchamiaj testów jednostkowych — projekt nie ma frameworka testowego.
+Przed zatwierdzeniem zmian uruchom `pnpm type:check`, `pnpm lint:check`, `pnpm format:check` i `pnpm test`.
+
+**Testy:** projekt ma framework testowy. **Vitest** pokrywa logikę bezframeworkową w `src/lib` (pliki `*.test.ts` obok kodu; wirtualny moduł `astro:content` jest aliasowany do `test/mocks/`). **Playwright** (`e2e/*.spec.ts`) uruchamia testy e2e i skan dostępności `@axe-core/playwright` na podglądzie `dist/` (`astro preview`); wymaga przeglądarki `pnpm exec playwright install chromium`. Dodając lub zmieniając czystą logikę w `src/lib`, dopisz testy jednostkowe.
 
 ## Stos i struktura
 
@@ -28,11 +34,13 @@ Przed zatwierdzeniem zmian uruchom `pnpm type:check`, `pnpm lint:check` i `pnpm 
 - **Build:** statyczny, wyjście w `dist/` (publicDir: `static/`).
 
 ```
-src/components/    # .astro (Seo, Menu, Breadcrumbs, Bio, Table, JsonLd) + wyspy React .tsx (Mermaid)
+src/components/    # .astro (Seo, Menu, Breadcrumbs, Bio, Table, JsonLd, ExternalLink, Figure) + wyspy React .tsx (Mermaid)
 src/layouts/       # PageLayout.astro (chrome: head/Seo, header, breadcrumbs, bio, footer)
 src/pages/         # index, blog, bio, contact, setup, metadata, files, 404, [...slug].astro, rss.xml.ts
 src/data/          # site-metadata.ts, structured-data.ts, gtag.ts
-src/lib/           # excerpt.ts
+src/lib/           # excerpt.ts, inline-markdown.ts, blog.ts, date.ts, page-metadata.ts (+ *.test.ts)
+src/types.ts       # współdzielone typy (PageMetadata, NavLink)
+e2e/               # testy Playwright (smoke, search, a11y); test/mocks/ — stuby dla Vitest
 src/integrations/  # webmanifest.ts (generuje manifest + ikony przez sharp w astro:build:done)
 src/scripts/       # web-vitals.ts (klienckie raportowanie do GA4)
 src/assets/        # obrazy przetwarzane przez astro:assets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ pnpm format:write   # Prettier — formatowanie
 pnpm format:check   # Prettier — sprawdzenie
 pnpm lint:fix       # ESLint — napraw
 pnpm lint:check     # ESLint — sprawdź
+pnpm lint:css       # Stylelint — sprawdź CSS
+pnpm lint:css:fix   # Stylelint — napraw CSS
 pnpm a11y:contrast  # audyt kontrastu design-tokenów (WCAG AA)
 pnpm test           # testy jednostkowe (Vitest, jednorazowo)
 pnpm test:watch     # Vitest w trybie watch
@@ -23,7 +25,7 @@ pnpm test:coverage  # Vitest + pokrycie (v8)
 pnpm test:e2e       # testy e2e + a11y (Playwright) na zbudowanym dist/
 ```
 
-Przed zatwierdzeniem zmian uruchom `pnpm type:check`, `pnpm lint:check`, `pnpm format:check` i `pnpm test`.
+Przed zatwierdzeniem zmian uruchom `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` i `pnpm test`.
 
 **Testy:** projekt ma framework testowy. **Vitest** pokrywa logikę bezframeworkową w `src/lib` (pliki `*.test.ts` obok kodu; wirtualny moduł `astro:content` jest aliasowany do `test/mocks/`). **Playwright** (`e2e/*.spec.ts`) uruchamia testy e2e i skan dostępności `@axe-core/playwright` na podglądzie `dist/` (`astro preview`); wymaga przeglądarki `pnpm exec playwright install chromium`. Dodając lub zmieniając czystą logikę w `src/lib`, dopisz testy jednostkowe.
 
@@ -66,7 +68,7 @@ Potrzebne przy modyfikacji `[...slug].astro`, `content.config.ts`, RSS (`rss.xml
 
 - **Komponenty:** statyczne pisz jako `.astro`; React (`.tsx`) tylko dla realnej interaktywności, jawnie hydratowany dyrektywą `client:*` (np. `client:load`, `client:visible`). Wyspy React: typ `FC`, nazwy PascalCase, importy hooków imienne.
 - **Pliki:** komponenty `.astro` PascalCase; skrypty/dane kebab-case. **Stałe:** UPPER_SNAKE_CASE.
-- **Style:** czyste CSS z custom properties (design tokens), bez preprocesorów; Montserrat (nagłówki), Merriweather (tekst). Dark mode automatyczny przez `prefers-color-scheme` (bez przełącznika JS).
+- **Style:** czyste CSS z custom properties (design tokens), bez preprocesorów; lintowane przez **Stylelint** (`stylelint-config-standard`, `normalize.css` wykluczony). Montserrat (nagłówki), Merriweather (tekst). Dark mode automatyczny przez `prefers-color-scheme` (bez przełącznika JS).
 - **Dane strukturalne:** JSON-LD przez `JsonLd.astro` (zwykłe obiekty, bez schema-dts).
 - **Prettier:** single quotes, średniki, 2 spacje, `printWidth: 120`, `arrowParens: avoid`, plugin `prettier-plugin-astro`.
 - **Komentarze:** tylko po angielsku i tylko te realnie wartościowe — wyjaśniaj „dlaczego”, a nie to, co kod już mówi sam.

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// axe-core scan per page — deeper than the design-token contrast audit: catches
+// ARIA, landmark, label and structural issues in the rendered DOM.
+const ROUTES = ['/', '/blog/', '/bio/', '/contact/', '/setup/', '/metadata/', '/files/'];
+
+for (const route of ROUTES) {
+  test(`${route} has no detectable WCAG A/AA violations`, async ({ page }) => {
+    await page.goto(route);
+    const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']).analyze();
+    expect(results.violations).toEqual([]);
+  });
+}

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('blog search', () => {
+  test('reports no results for a nonsense query and restores the list when cleared', async ({ page }) => {
+    await page.goto('/blog/');
+    const input = page.locator('#blog-search-input');
+
+    await input.fill('zzzzz-nonexistent-term');
+    await expect(page.locator('#blog-search-status')).toContainText('Brak wyników');
+    await expect(page.locator('#blog-posts')).toBeHidden();
+
+    await input.fill('');
+    await expect(page.locator('#blog-posts')).toBeVisible();
+  });
+
+  test('clicking a tag chip runs a search for that tag', async ({ page }) => {
+    await page.goto('/blog/');
+    const firstTag = page.locator('#blog-posts .tag').first();
+    const tag = await firstTag.getAttribute('data-tag');
+    expect(tag).toBeTruthy();
+
+    await firstTag.click();
+    await expect(page.locator('#blog-search-input')).toHaveValue(tag as string);
+    await expect(page.locator('#blog-search-results')).toBeVisible();
+  });
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// Core static routes that must always render with a title, a single visible H1
+// and a canonical link (the SEO chrome the build contract also guards).
+const ROUTES = ['/', '/blog/', '/bio/', '/contact/', '/setup/', '/metadata/', '/files/'];
+
+for (const route of ROUTES) {
+  test(`${route} renders core SEO chrome`, async ({ page }) => {
+    const response = await page.goto(route);
+    expect(response?.ok()).toBeTruthy();
+
+    await expect(page).toHaveTitle(/.+/);
+    await expect(page.locator('h1').first()).toBeVisible();
+
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveAttribute('href', /^https:\/\/dawidrylko\.com\//);
+
+    const description = page.locator('meta[name="description"]');
+    await expect(description).toHaveAttribute('content', /.+/);
+  });
+}
+
+test('a blog post page renders and links back to the blog', async ({ page }) => {
+  await page.goto('/blog/');
+  const firstPost = page.locator('#blog-posts .post-list-item h2 a').first();
+  const href = await firstPost.getAttribute('href');
+  expect(href).toBeTruthy();
+
+  const response = await page.goto(href as string);
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.locator('article.blog-post h1')).toBeVisible();
+  await expect(page.locator('.breadcrumbs a', { hasText: 'Blog' })).toBeVisible();
+});
+
+test('unknown route serves the 404 page', async ({ page }) => {
+  const response = await page.goto('/no-such-page-please/');
+  expect(response?.status()).toBe(404);
+  await expect(page.locator('h1')).toContainText('Page Not Found');
+});
+
+test('dark mode applies the dark background token', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.goto('/');
+  const background = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+  // --color-background under prefers-color-scheme: dark is #1a1f27.
+  expect(background).toBe('rgb(26, 31, 39)');
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import astro from 'eslint-plugin-astro';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 import globals from 'globals';
 
 export default [
@@ -9,5 +10,16 @@ export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...astro.configs.recommended,
+  // Accessibility linting for the React islands (.tsx).
+  { ...jsxA11y.flatConfigs.recommended, files: ['**/*.{jsx,tsx}'] },
+  // Prefer `import type` so type-only imports are erased and never bundled.
+  {
+    files: ['**/*.{ts,tsx}'],
+    rules: { '@typescript-eslint/consistent-type-imports': 'error' },
+  },
+  // Flag stray debug logging in shipped site source; warn/error are allowed.
+  // CLI helpers and the interactive memoization demo log on purpose.
+  { files: ['src/**/*.{ts,tsx,astro}'], rules: { 'no-console': ['warn', { allow: ['warn', 'error'] }] } },
+  { files: ['src/demo/**'], rules: { 'no-console': 'off' } },
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
 ];

--- a/helpers/ci/check-seo-meta.mjs
+++ b/helpers/ci/check-seo-meta.mjs
@@ -80,7 +80,10 @@ function checkPage(page, html) {
   if (!description || !description[1].trim()) fail(`${page}: missing or empty meta description`);
 
   const canonical = html.match(/<link[^>]*rel="canonical"[^>]*href="([^"]*)"/);
-  if (!canonical || !canonical[1].startsWith(ORIGIN)) fail(`${page}: missing or non-canonical canonical link`);
+  // Compare the parsed origin (not a substring) so a look-alike host such as
+  // https://dawidrylko.com.evil.com/ cannot pass the check.
+  const canonicalOrigin = canonical && URL.canParse(canonical[1]) ? new URL(canonical[1]).origin : null;
+  if (canonicalOrigin !== ORIGIN) fail(`${page}: missing or non-canonical canonical link`);
 
   for (const [i, block] of ldJsonBlocks(html).entries()) {
     try {

--- a/helpers/ci/check-seo-meta.mjs
+++ b/helpers/ci/check-seo-meta.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * SEO / structured-data contract for the Astro build (dist/).
+ *
+ * Walks every rendered HTML page and asserts the baseline discoverability
+ * chrome that must never silently regress:
+ *
+ *   - a non-empty <title>
+ *   - a non-empty <meta name="description">
+ *   - a <link rel="canonical"> pointing at the production origin
+ *   - every <script type="application/ld+json"> block is valid JSON
+ *
+ * Plus site-wide structured-data guarantees:
+ *
+ *   - blog post pages carry a BlogPosting JSON-LD node
+ *
+ * Redirect stubs (meta-refresh pages such as /resume/) are skipped. Zero
+ * dependencies; runs against the built output, it does NOT rebuild. Exits
+ * non-zero listing every page that fails.
+ */
+
+import { readFile, readdir, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : resolve(__dirname, '../../dist');
+const ORIGIN = 'https://dawidrylko.com';
+
+const problems = [];
+const fail = msg => problems.push(msg);
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Recursively collect every .html file under dir. */
+async function collectHtml(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return collectHtml(full);
+      return entry.name.endsWith('.html') ? [full] : [];
+    }),
+  );
+  return files.flat();
+}
+
+function ldJsonBlocks(html) {
+  return [...html.matchAll(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g)].map(m => m[1]);
+}
+
+function checkPage(page, html) {
+  // Redirect stubs have no real <head> chrome — skip them.
+  if (/http-equiv="refresh"/i.test(html)) return null;
+
+  const title = html.match(/<title>([\s\S]*?)<\/title>/);
+  if (!title || !title[1].trim()) fail(`${page}: missing or empty <title>`);
+
+  const description = html.match(/<meta[^>]*name="description"[^>]*content="([^"]*)"/);
+  if (!description || !description[1].trim()) fail(`${page}: missing or empty meta description`);
+
+  const canonical = html.match(/<link[^>]*rel="canonical"[^>]*href="([^"]*)"/);
+  if (!canonical || !canonical[1].startsWith(ORIGIN)) fail(`${page}: missing or non-canonical canonical link`);
+
+  for (const [i, block] of ldJsonBlocks(html).entries()) {
+    try {
+      JSON.parse(block);
+    } catch (err) {
+      fail(`${page}: invalid JSON-LD block #${i + 1} (${err.message})`);
+    }
+  }
+
+  return html;
+}
+
+async function main() {
+  if (!(await exists(DIST_DIR))) {
+    console.error(`Build output not found at ${DIST_DIR}. Run "pnpm build" first.`);
+    process.exit(1);
+  }
+
+  const pages = await collectHtml(DIST_DIR);
+  if (pages.length === 0) fail('no HTML pages found in dist');
+
+  let postsWithBlogPosting = 0;
+  for (const page of pages) {
+    const rel = relative(DIST_DIR, page);
+    const html = await readFile(page, 'utf8');
+    const checked = checkPage(rel, html);
+    if (checked && ldJsonBlocks(checked).some(b => b.includes('"BlogPosting"'))) {
+      postsWithBlogPosting += 1;
+    }
+  }
+
+  // The blog has published posts, so at least one BlogPosting node must ship.
+  if (postsWithBlogPosting === 0) {
+    fail('no page emits a BlogPosting JSON-LD node (blog structured data regressed)');
+  }
+
+  console.log('SEO / structured-data contract (dist/)\n');
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(`  ✗ ${problem}`);
+    console.error(`\nSEO contract failed: ${problems.length} problem(s).`);
+    process.exit(1);
+  }
+  console.log(`  ✓ ${pages.length} page(s): title, description, canonical and valid JSON-LD; BlogPosting present.`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/helpers/ci/check-seo-meta.mjs
+++ b/helpers/ci/check-seo-meta.mjs
@@ -13,6 +13,8 @@
  * Plus site-wide structured-data guarantees:
  *
  *   - blog post pages carry a BlogPosting JSON-LD node
+ *   - blog post pages declare og:type=article + article:published_time
+ *   - every page emits a WebSite JSON-LD node (site-wide search action)
  *
  * Redirect stubs (meta-refresh pages such as /resume/) are skipped. Zero
  * dependencies; runs against the built output, it does NOT rebuild. Exits
@@ -56,6 +58,17 @@ function ldJsonBlocks(html) {
   return [...html.matchAll(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g)].map(m => m[1]);
 }
 
+/** Root @type(s) of a JSON-LD block, ignoring nodes nested inside it. */
+function rootTypes(block) {
+  try {
+    const data = JSON.parse(block);
+    const nodes = Array.isArray(data) ? data : [data];
+    return nodes.flatMap(node => (node && node['@type'] ? [node['@type']] : []));
+  } catch {
+    return [];
+  }
+}
+
 function checkPage(page, html) {
   // Redirect stubs have no real <head> chrome — skip them.
   if (/http-equiv="refresh"/i.test(html)) return null;
@@ -90,18 +103,42 @@ async function main() {
   if (pages.length === 0) fail('no HTML pages found in dist');
 
   let postsWithBlogPosting = 0;
+  let pagesWithWebSite = 0;
+  let indexablePages = 0;
   for (const page of pages) {
     const rel = relative(DIST_DIR, page);
     const html = await readFile(page, 'utf8');
     const checked = checkPage(rel, html);
-    if (checked && ldJsonBlocks(checked).some(b => b.includes('"BlogPosting"'))) {
+    if (!checked) continue;
+
+    indexablePages += 1;
+    const types = ldJsonBlocks(checked).flatMap(rootTypes);
+    if (types.includes('WebSite')) pagesWithWebSite += 1;
+
+    // Only individual post pages have a root BlogPosting node; blog listing pages
+    // nest BlogPosting items inside a Blog node and must not be treated as posts.
+    if (types.includes('BlogPosting')) {
       postsWithBlogPosting += 1;
+      // A post page must present itself as an article with a publish date, or
+      // social/LLM crawlers lose the post's timeline.
+      if (!/<meta[^>]*property="og:type"[^>]*content="article"/.test(checked)) {
+        fail(`${rel}: BlogPosting page is missing og:type=article`);
+      }
+      if (!/<meta[^>]*property="article:published_time"[^>]*content="[^"]+"/.test(checked)) {
+        fail(`${rel}: BlogPosting page is missing article:published_time`);
+      }
     }
   }
 
   // The blog has published posts, so at least one BlogPosting node must ship.
   if (postsWithBlogPosting === 0) {
     fail('no page emits a BlogPosting JSON-LD node (blog structured data regressed)');
+  }
+
+  // The WebSite node (with its search action) is emitted by the shared layout,
+  // so every indexable page must carry it.
+  if (pagesWithWebSite !== indexablePages) {
+    fail(`WebSite JSON-LD missing on ${indexablePages - pagesWithWebSite} of ${indexablePages} page(s)`);
   }
 
   console.log('SEO / structured-data contract (dist/)\n');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "format:write": "prettier --write \"**/*.{astro,ts,tsx,js,mjs,json,md}\"",
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:css": "stylelint \"src/**/*.css\"",
+    "lint:css:fix": "stylelint \"src/**/*.css\" --fix",
     "a11y:contrast": "node helpers/a11y-contrast/check-contrast.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -52,17 +54,21 @@
     "astro": "^6.4.8",
     "eslint": "^10.5.0",
     "eslint-plugin-astro": "^1.7.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
+    "stylelint": "^17.13.0",
+    "stylelint-config-standard": "^40.0.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
     "vitest": "^4.1.9"
   },
   "lint-staged": {
     "**/*.{astro,ts,tsx,js,mjs,json,md}": "prettier --write",
-    "**/*.{astro,ts,tsx,js,mjs}": "eslint --fix"
+    "**/*.{astro,ts,tsx,js,mjs}": "eslint --fix",
+    "src/**/*.css": "stylelint --fix"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
     "a11y:contrast": "node helpers/a11y-contrast/check-contrast.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "dependencies": {
@@ -39,9 +43,12 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@axe-core/playwright": "^4.11.3",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.61.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@vitest/coverage-v8": "^4.1.9",
     "astro": "^6.4.8",
     "eslint": "^10.5.0",
     "eslint-plugin-astro": "^1.7.0",
@@ -51,7 +58,8 @@
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.1"
+    "typescript-eslint": "^8.61.1",
+    "vitest": "^4.1.9"
   },
   "lint-staged": {
     "**/*.{astro,ts,tsx,js,mjs,json,md}": "prettier --write",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// End-to-end / a11y smoke tests run against the built site served by
+// `astro preview` (dist/). CI builds dist once and reuses it here.
+const PORT = 4321;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'pnpm preview',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,15 +54,24 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.61.0)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.5.0)
+      '@playwright/test':
+        specifier: ^1.61.0
+        version: 1.61.0
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.17)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       astro:
         specifier: ^6.4.8
         version: 6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)
@@ -93,6 +102,9 @@ importers:
       typescript-eslint:
         specifier: ^8.61.1
         version: 8.61.1(eslint@10.5.0)(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0))
 
 packages:
 
@@ -167,6 +179,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.4':
     resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -250,6 +267,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -875,6 +896,11 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1056,6 +1082,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1067,6 +1096,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -1163,6 +1195,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1291,6 +1326,44 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
     peerDependencies:
@@ -1381,6 +1454,13 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -1399,6 +1479,10 @@ packages:
     engines: {node: ^18.18.0 || >=20.9.0}
     peerDependencies:
       '@astrojs/compiler': '>=0.27.0'
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1437,6 +1521,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1935,6 +2023,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -2012,6 +2104,11 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2058,6 +2155,10 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hast-util-from-dom@5.0.1:
     resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
 
@@ -2099,6 +2200,9 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -2207,6 +2311,21 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2305,6 +2424,10 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -2621,6 +2744,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -2634,6 +2760,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -2865,6 +3001,9 @@ packages:
     resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2899,6 +3038,12 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -2945,6 +3090,10 @@ packages:
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -2957,6 +3106,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.14:
     resolution: {integrity: sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -2968,6 +3120,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3197,6 +3353,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -3312,6 +3509,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3536,6 +3738,11 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.61.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.61.0
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3647,6 +3854,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -4107,6 +4316,10 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/pluginutils@5.4.0(rollup@4.62.0)':
@@ -4232,6 +4445,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.7
@@ -4252,6 +4467,11 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -4373,6 +4593,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -4537,6 +4759,61 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0))
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@24.13.2)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-service': 2.4.28
@@ -4639,6 +4916,14 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -4757,6 +5042,8 @@ snapshots:
       '@astrojs/compiler': 3.0.1
       synckit: 0.11.13
 
+  axe-core@4.11.4: {}
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -4786,6 +5073,8 @@ snapshots:
   caniuse-lite@1.0.30001799: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -5341,6 +5630,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expect-type@1.3.0: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -5421,6 +5712,9 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5461,6 +5755,8 @@ snapshots:
       uncrypto: 0.1.3
 
   hachure-fill@0.5.2: {}
+
+  has-flag@4.0.0: {}
 
   hast-util-from-dom@5.0.1:
     dependencies:
@@ -5603,6 +5899,8 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  html-escaper@2.0.2: {}
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -5673,6 +5971,21 @@ snapshots:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5770,6 +6083,10 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   markdown-extensions@2.0.0: {}
 
@@ -6386,6 +6703,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  pathe@2.0.3: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -6393,6 +6712,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 
@@ -6771,6 +7098,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -6799,6 +7128,10 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -6852,6 +7185,10 @@ snapshots:
     dependencies:
       s.color: 0.0.15
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -6868,6 +7205,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.14: {}
 
   tinyexec@1.2.4: {}
@@ -6876,6 +7215,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7044,6 +7385,34 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@24.13.2)(yaml@2.9.0)
 
+  vitest@4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.5(@types/node@24.13.2)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.2
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+    transitivePeerDependencies:
+      - msw
+
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
@@ -7159,6 +7528,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       eslint-plugin-astro:
         specifier: ^1.7.0
         version: 1.7.0(eslint@10.5.0)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@10.5.0)
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -96,6 +99,12 @@ importers:
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
+      stylelint:
+        specifier: ^17.13.0
+        version: 17.13.0(typescript@6.0.3)
+      stylelint-config-standard:
+        specifier: ^40.0.0
+        version: 40.0.0(stylelint@17.13.0(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -275,6 +284,12 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@cacheable/memory@2.0.9':
+    resolution: {integrity: sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==}
+
+  '@cacheable/utils@2.4.1':
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
+
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
@@ -289,6 +304,50 @@ packages:
   '@clack/prompts@1.5.1':
     resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
     engines: {node: '>= 20.12.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/media-query-list-parser@5.0.0':
+    resolution: {integrity: sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0':
+    resolution: {integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -868,6 +927,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -1081,6 +1149,10 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1451,15 +1523,42 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -1480,6 +1579,14 @@ packages:
     peerDependencies:
       '@astrojs/compiler': '>=0.27.0'
 
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
   axe-core@4.11.4:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
@@ -1490,6 +1597,9 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1503,6 +1613,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -1515,6 +1628,25 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  cacheable@2.3.5:
+    resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
@@ -1576,6 +1708,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -1602,6 +1737,9 @@ packages:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1618,12 +1756,25 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1808,6 +1959,21 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
@@ -1825,6 +1991,14 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -1873,6 +2047,10 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.375:
     resolution: {integrity: sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==}
 
@@ -1884,6 +2062,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1897,12 +2078,51 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-abstract-get@1.0.0:
+    resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
+    engines: {node: '>= 0.4'}
+
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.1:
+    resolution: {integrity: sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==}
+    engines: {node: '>= 0.4'}
 
   es-toolkit@1.47.1:
     resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
@@ -1941,6 +2161,12 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.57.0'
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -2062,6 +2288,10 @@ packages:
     resolution: {integrity: sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w==}
     hasBin: true
 
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2073,6 +2303,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-entry-cache@11.1.3:
+    resolution: {integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2090,6 +2323,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flat-cache@6.1.22:
+    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -2104,6 +2340,10 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2113,6 +2353,20 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.2.0:
+    resolution: {integrity: sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2125,6 +2379,18 @@ packages:
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
@@ -2141,6 +2407,14 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
+
   globals@16.5.0:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
@@ -2149,15 +2423,61 @@ packages:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  globby@16.2.0:
+    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
+    engines: {node: '>=20'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   hast-util-from-dom@5.0.1:
     resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
@@ -2201,11 +2521,21 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-tags@5.1.0:
+    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
+    engines: {node: '>=20.10'}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -2230,6 +2560,10 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -2237,8 +2571,15 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
 
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
@@ -2256,6 +2597,37 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
@@ -2269,9 +2641,17 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  is-document.all@1.0.0:
+    resolution: {integrity: sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==}
+    engines: {node: '>= 0.4'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -2280,6 +2660,10 @@ packages:
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2293,20 +2677,75 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
   is-unsafe@1.0.1:
     resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
 
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2341,6 +2780,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2361,6 +2803,10 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
@@ -2372,12 +2818,26 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -2388,6 +2848,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
@@ -2404,6 +2867,9 @@ packages:
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -2440,6 +2906,13 @@ packages:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mathml-tag-names@4.0.0:
+    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -2500,6 +2973,10 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2628,6 +3105,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -2670,6 +3150,26 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -2694,6 +3194,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2717,8 +3221,16 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
@@ -2777,9 +3289,22 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -2808,6 +3333,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2850,6 +3379,10 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -2858,6 +3391,10 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
@@ -2913,6 +3450,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2959,6 +3500,18 @@ packages:
   s.color@0.0.15:
     resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
 
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2981,6 +3534,18 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3001,6 +3566,22 @@ packages:
     resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
     engines: {node: '>=20'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -3015,6 +3596,14 @@ packages:
     resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
@@ -3045,6 +3634,10 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
@@ -3063,6 +3656,22 @@ packages:
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trim@1.2.11:
+    resolution: {integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.10:
+    resolution: {integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -3084,15 +3693,43 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  stylelint-config-recommended@18.0.0:
+    resolution: {integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint-config-standard@40.0.0:
+    resolution: {integrity: sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint@17.13.0:
+    resolution: {integrity: sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-hyperlinks@4.5.0:
+    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
+    engines: {node: '>=20'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -3102,6 +3739,10 @@ packages:
   synckit@0.11.13:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -3152,6 +3793,22 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.8:
+    resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
+    engines: {node: '>= 0.4'}
+
   typesafe-path@0.2.2:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
 
@@ -3176,11 +3833,19 @@ packages:
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3502,9 +4167,29 @@ packages:
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3527,6 +4212,10 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
@@ -3859,6 +4548,18 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@cacheable/memory@2.0.9':
+    dependencies:
+      '@cacheable/utils': 2.4.1
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.4.1':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@capsizecss/unpack@4.0.1':
     dependencies:
       fontkitten: 1.0.3
@@ -3876,6 +4577,34 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/media-query-list-parser@5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.4)':
+    dependencies:
+      postcss-selector-parser: 7.1.4
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.4)':
+    dependencies:
+      postcss-selector-parser: 7.1.4
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -4264,6 +4993,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
@@ -4444,6 +5181,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4915,15 +5654,59 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
   array-iterate@2.0.1: {}
 
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
   assertion-error@2.0.1: {}
+
+  ast-types-flow@0.0.8: {}
 
   ast-v8-to-istanbul@1.0.4:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  astral-regex@2.0.0: {}
 
   astring@1.9.0: {}
 
@@ -5042,17 +5825,30 @@ snapshots:
       '@astrojs/compiler': 3.0.1
       synckit: 0.11.13
 
+  async-function@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
   axe-core@4.11.4: {}
 
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.38: {}
 
   boolbase@1.0.0: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.6:
     dependencies:
@@ -5069,6 +5865,33 @@ snapshots:
       electron-to-chromium: 1.5.375
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  cacheable@2.3.5:
+    dependencies:
+      '@cacheable/memory': 2.0.9
+      '@cacheable/utils': 2.4.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001799: {}
 
@@ -5119,6 +5942,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colord@2.9.3: {}
+
   colorette@2.0.20: {}
 
   comma-separated-tokens@2.0.3: {}
@@ -5132,6 +5957,8 @@ snapshots:
   commander@8.3.0: {}
 
   common-ancestor-path@2.0.0: {}
+
+  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -5147,6 +5974,15 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
+  cosmiconfig@9.0.2(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5156,6 +5992,8 @@ snapshots:
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
+
+  css-functions-list@3.3.3: {}
 
   css-select@5.2.2:
     dependencies:
@@ -5369,6 +6207,26 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  damerau-levenshtein@1.0.8: {}
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   dayjs@1.11.21: {}
 
   debug@4.4.3:
@@ -5380,6 +6238,18 @@ snapshots:
       character-entities: 2.0.2
 
   deep-is@0.1.4: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   defu@6.1.7: {}
 
@@ -5425,6 +6295,12 @@ snapshots:
 
   dset@3.1.4: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.5.375: {}
 
   emmet@2.4.11:
@@ -5436,15 +6312,114 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  emoji-regex@9.2.2: {}
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
 
   entities@7.0.1: {}
 
+  env-paths@2.2.1: {}
+
   environment@1.1.0: {}
 
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-abstract-get@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      is-callable: 1.2.7
+      object-inspect: 1.13.4
+
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.1
+      function.prototype.name: 1.2.0
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.11
+      string.prototype.trimend: 1.0.10
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.8
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.22
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.4
+
+  es-to-primitive@1.3.1:
+    dependencies:
+      es-abstract-get: 1.0.0
+      es-errors: 1.3.0
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   es-toolkit@1.47.1: {}
 
@@ -5515,6 +6490,25 @@ snapshots:
       postcss-selector-parser: 7.1.4
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@10.5.0):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.4
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 10.5.0
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-scope@8.4.0:
     dependencies:
@@ -5674,6 +6668,8 @@ snapshots:
       strnum: 2.4.0
       xml-naming: 0.1.0
 
+  fastest-levenshtein@1.0.16: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -5681,6 +6677,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-entry-cache@11.1.3:
+    dependencies:
+      flat-cache: 6.1.22
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5700,6 +6700,12 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
+  flat-cache@6.1.22:
+    dependencies:
+      cacheable: 2.3.5
+      flatted: 3.4.2
+      hookified: 1.15.1
+
   flatted@3.4.2: {}
 
   flattie@1.1.1: {}
@@ -5712,17 +6718,63 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.2.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+      hasown: 2.0.4
+      is-callable: 1.2.7
+      is-document.all: 1.0.0
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
 
   get-tsconfig@5.0.0-beta.4:
     dependencies:
@@ -5738,9 +6790,37 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
   globals@16.5.0: {}
 
   globals@17.6.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  globby@16.2.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  globjoin@0.1.4: {}
+
+  gopd@1.2.0: {}
 
   h3@1.15.11:
     dependencies:
@@ -5756,7 +6836,33 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  has-bigints@1.1.0: {}
+
   has-flag@4.0.0: {}
+
+  has-flag@5.0.1: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-from-dom@5.0.1:
     dependencies:
@@ -5899,9 +7005,15 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
+
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
+
+  html-tags@5.1.0: {}
 
   html-void-elements@3.0.0: {}
 
@@ -5917,11 +7029,24 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
+  ini@1.3.8: {}
+
   inline-style-parser@0.2.7: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.4
+      side-channel: 1.1.1
 
   internmap@1.0.1: {}
 
@@ -5936,19 +7061,73 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
   is-docker@4.0.0: {}
 
+  is-document.all@1.0.0:
+    dependencies:
+      call-bound: 1.0.4
+
   is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.6.0
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -5960,15 +7139,67 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
+
   is-unsafe@1.0.1: {}
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
 
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -5997,6 +7228,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -6008,6 +7241,13 @@ snapshots:
   jsonc-parser@2.3.1: {}
 
   jsonc-parser@3.3.1: {}
+
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
 
   katex@0.16.47:
     dependencies:
@@ -6021,9 +7261,21 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   khroma@2.1.0: {}
 
+  kind-of@6.0.3: {}
+
   kleur@4.1.5: {}
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   layout-base@1.0.2: {}
 
@@ -6033,6 +7285,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lines-and-columns@1.2.4: {}
 
   lint-staged@16.4.0:
     dependencies:
@@ -6057,6 +7311,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash-es@4.18.1: {}
+
+  lodash.truncate@4.4.2: {}
 
   log-update@6.1.0:
     dependencies:
@@ -6093,6 +7349,10 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  math-intrinsics@1.1.0: {}
+
+  mathml-tag-names@4.0.0: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -6278,6 +7538,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
+
+  meow@14.1.0: {}
 
   merge2@1.4.1: {}
 
@@ -6590,6 +7852,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -6617,6 +7883,33 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
 
   obug@2.1.3: {}
 
@@ -6649,6 +7942,12 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -6670,6 +7969,10 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -6679,6 +7982,13 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   parse-latin@7.0.0:
     dependencies:
@@ -6728,10 +8038,18 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
+  possible-typed-array-names@1.1.0: {}
+
+  postcss-safe-parser@7.0.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
   postcss-selector-parser@7.1.4:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.15:
     dependencies:
@@ -6754,6 +8072,10 @@ snapshots:
   property-information@7.2.0: {}
 
   punycode@2.3.1: {}
+
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
 
   queue-microtask@1.2.3: {}
 
@@ -6801,6 +8123,17 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -6810,6 +8143,15 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   rehype-katex@7.0.1:
     dependencies:
@@ -6919,6 +8261,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-from@4.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
@@ -7003,6 +8347,25 @@ snapshots:
 
   s.color@0.0.15: {}
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
 
   sass-formatter@0.7.9:
@@ -7016,6 +8379,28 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.4: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
 
   sharp@0.34.5:
     dependencies:
@@ -7098,6 +8483,34 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -7110,6 +8523,14 @@ snapshots:
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.6.0
+
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   slice-ansi@7.1.2:
     dependencies:
@@ -7133,6 +8554,11 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
   stream-replace-string@2.0.0: {}
 
   string-argv@0.3.2: {}
@@ -7153,6 +8579,36 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
+
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.trim@1.2.11:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      has-property-descriptors: 1.0.2
+      safe-regex-test: 1.1.0
+
+  string.prototype.trimend@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
 
   stringify-entities@4.0.4:
     dependencies:
@@ -7179,15 +8635,74 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylelint-config-recommended@18.0.0(stylelint@17.13.0(typescript@6.0.3)):
+    dependencies:
+      stylelint: 17.13.0(typescript@6.0.3)
+
+  stylelint-config-standard@40.0.0(stylelint@17.13.0(typescript@6.0.3)):
+    dependencies:
+      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@6.0.3))
+
+  stylelint@17.13.0(typescript@6.0.3):
+    dependencies:
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.4)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.4)
+      colord: 2.9.3
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      css-functions-list: 3.3.3
+      css-tree: 3.2.1
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.3
+      global-modules: 2.0.0
+      globby: 16.2.0
+      globjoin: 0.1.4
+      html-tags: 5.1.0
+      ignore: 7.0.5
+      import-meta-resolve: 4.2.0
+      mathml-tag-names: 4.0.0
+      meow: 14.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-safe-parser: 7.0.1(postcss@8.5.15)
+      postcss-selector-parser: 7.1.4
+      postcss-value-parser: 4.2.0
+      string-width: 8.2.1
+      supports-hyperlinks: 4.5.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   stylis@4.4.0: {}
 
   suf-log@2.5.3:
     dependencies:
       s.color: 0.0.15
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@4.5.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
+  svg-tags@1.0.0: {}
 
   svgo@4.0.1:
     dependencies:
@@ -7202,6 +8717,14 @@ snapshots:
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.20.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tiny-inflate@1.0.3: {}
 
@@ -7239,6 +8762,39 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typesafe-path@0.2.2: {}
 
   typescript-auto-import-cache@0.3.6:
@@ -7262,9 +8818,18 @@ snapshots:
 
   ultrahtml@1.6.0: {}
 
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
   uncrypto@0.1.3: {}
 
   undici-types@7.18.2: {}
+
+  unicorn-magic@0.4.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -7523,7 +9088,52 @@ snapshots:
 
   web-vitals@5.3.0: {}
 
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.2.0
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.22
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
   which-pm-runs@1.1.0: {}
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
 
   which@2.0.2:
     dependencies:
@@ -7547,6 +9157,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   xml-naming@0.1.0: {}
 

--- a/src/components/Bio.astro
+++ b/src/components/Bio.astro
@@ -4,6 +4,7 @@ import avatar from '../assets/avatar.jpeg';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
 import JsonLd from './JsonLd.astro';
+import ExternalLink from './ExternalLink.astro';
 
 // Port of src/components/bio.tsx (author card + Person JSON-LD).
 const author = SITE_METADATA.author;
@@ -24,9 +25,9 @@ const { person } = STRUCTURED_DATA;
       {
         social.map(({ name, url, follow }) => (
           <li>
-            <a href={url} target="_blank" rel={follow ? 'noopener noreferrer' : 'noopener noreferrer nofollow'}>
+            <ExternalLink href={url} follow={follow}>
               {name}
-            </a>
+            </ExternalLink>
           </li>
         ))
       }

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,6 +1,7 @@
 ---
 import { SITE_METADATA } from '../data/site-metadata';
 import JsonLd from './JsonLd.astro';
+import type { NavLink } from '../types';
 
 // Port of src/components/breadcrumbs.tsx. Builds the trail from the current
 // pathname, mapping known menu segments to their labels and using the page's
@@ -10,7 +11,7 @@ interface Props {
   // Extra ancestor crumbs inserted between Home and the path-derived trail.
   // Used e.g. by blog posts (URL is /slug/, but the trail should read
   // Home › Blog › Post) without changing the post URL.
-  parents?: { name: string; url: string }[];
+  parents?: NavLink[];
 }
 
 const { customTitle, parents = [] } = Astro.props;

--- a/src/components/ExternalLink.astro
+++ b/src/components/ExternalLink.astro
@@ -1,0 +1,15 @@
+---
+// Outbound link that opens in a new tab with a safe `rel`. `noopener noreferrer`
+// is always set; `nofollow` is added unless `follow` is true. Any extra
+// attributes (title, aria-label, class…) pass through to the anchor.
+interface Props {
+  href: string;
+  follow?: boolean;
+  [key: string]: unknown;
+}
+
+const { href, follow = false, ...rest } = Astro.props;
+const rel = follow ? 'noopener noreferrer' : 'noopener noreferrer nofollow';
+---
+
+<a href={href} target="_blank" rel={rel} {...rest}><slot /></a>

--- a/src/components/Figure.astro
+++ b/src/components/Figure.astro
@@ -1,0 +1,20 @@
+---
+import { Picture } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+
+// Responsive image with an optional caption — the repeated
+// <figure><Picture/><figcaption/></figure> pattern from the bio, setup and 404
+// pages. Emits AVIF/WebP sources at full container width.
+interface Props {
+  src: ImageMetadata;
+  alt: string;
+  caption?: string;
+}
+
+const { src, alt, caption } = Astro.props;
+---
+
+<figure class="figure">
+  <Picture src={src} formats={['avif', 'webp']} layout="full-width" alt={alt} />
+  {caption && <figcaption>{caption}</figcaption>}
+</figure>

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -9,15 +9,36 @@ interface Props {
   description?: string;
   pathname?: string;
   image?: string;
+  imageAlt?: string;
+  imageWidth?: number;
+  imageHeight?: number;
   article?: boolean;
+  publishedTime?: string;
+  modifiedTime?: string;
+  tags?: string[];
   noIndex?: boolean;
   lang?: string;
 }
 
-const { title, description, pathname, image, article, noIndex, lang } = Astro.props;
+const {
+  title,
+  description,
+  pathname,
+  image,
+  imageAlt,
+  imageWidth,
+  imageHeight,
+  article,
+  publishedTime,
+  modifiedTime,
+  tags,
+  noIndex,
+  lang,
+} = Astro.props;
 
 // Square brand icon emitted by the PWA manifest; OG/Twitter fallback image.
 const DEFAULT_OG_IMAGE = '/icons/icon-512x512.png';
+const DEFAULT_OG_IMAGE_SIZE = 512;
 const OG_LOCALES: Record<string, string> = { en: 'en_US', pl: 'pl_PL' };
 
 const metaLang = lang ?? SITE_METADATA.lang;
@@ -27,6 +48,7 @@ const author = SITE_METADATA.author;
 
 const metaDescription = description || siteDescription;
 const metaTitle = title ? `${title} | ${siteTitle}` : `${siteTitle} | ${author.jobTitle}`;
+const metaImageAlt = imageAlt ?? metaTitle;
 
 const twitterUrl = SITE_METADATA.social.find(({ name }) => name === 'Twitter')?.url ?? '';
 const twitterHandle = twitterUrl ? `@${twitterUrl.replace(/\/$/, '').split('/').pop()}` : '';
@@ -34,25 +56,65 @@ const twitterHandle = twitterUrl ? `@${twitterUrl.replace(/\/$/, '').split('/').
 const baseUrl = SITE_METADATA.url.replace(/\/$/, '');
 const canonicalUrl = `${baseUrl}${pathname ?? Astro.url.pathname}`;
 const imageUrl = `${baseUrl}${image ?? DEFAULT_OG_IMAGE}`;
+
+// Open Graph image dimensions/type help crawlers render large cards without
+// fetching the bitmap. Posts pass explicit dimensions for their featured image;
+// the default brand icon is a known 512×512 PNG.
+const ogImageWidth = imageWidth ?? (image ? undefined : DEFAULT_OG_IMAGE_SIZE);
+const ogImageHeight = imageHeight ?? (image ? undefined : DEFAULT_OG_IMAGE_SIZE);
+const OG_IMAGE_TYPES: Record<string, string> = {
+  png: 'image/png',
+  webp: 'image/webp',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  avif: 'image/avif',
+  gif: 'image/gif',
+};
+const ogImageType = OG_IMAGE_TYPES[imageUrl.split('.').pop()?.toLowerCase() ?? ''];
+
+// Indexable pages spell out generous snippet/preview limits so search engines
+// and LLM crawlers can surface rich excerpts and large thumbnails.
+const robots = noIndex
+  ? 'noindex, nofollow'
+  : 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1';
 ---
 
 <title>{metaTitle}</title>
 <meta name="description" content={metaDescription} />
+<meta name="robots" content={robots} />
+<meta name="author" content={author.name} />
 
 <meta property="og:title" content={metaTitle} />
 <meta property="og:description" content={metaDescription} />
 <meta property="og:type" content={article ? 'article' : 'website'} />
 <meta property="og:url" content={canonicalUrl} />
 <meta property="og:image" content={imageUrl} />
-<meta property="og:image:alt" content={metaTitle} />
+<meta property="og:image:alt" content={metaImageAlt} />
+{ogImageType && <meta property="og:image:type" content={ogImageType} />}
+{ogImageWidth && <meta property="og:image:width" content={String(ogImageWidth)} />}
+{ogImageHeight && <meta property="og:image:height" content={String(ogImageHeight)} />}
 <meta property="og:site_name" content={siteTitle} />
 <meta property="og:locale" content={OG_LOCALES[metaLang] ?? metaLang} />
+
+{
+  article && (
+    <>
+      <meta property="article:author" content={author.name} />
+      {publishedTime && <meta property="article:published_time" content={publishedTime} />}
+      {(modifiedTime ?? publishedTime) && (
+        <meta property="article:modified_time" content={modifiedTime ?? publishedTime} />
+      )}
+      {tags?.map(tag => (
+        <meta property="article:tag" content={tag} />
+      ))}
+    </>
+  )
+}
 
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content={metaTitle} />
 <meta name="twitter:description" content={metaDescription} />
 <meta name="twitter:image" content={imageUrl} />
+<meta name="twitter:image:alt" content={metaImageAlt} />
 {twitterHandle && <meta name="twitter:site" content={twitterHandle} />}
 {twitterHandle && <meta name="twitter:creator" content={twitterHandle} />}
-
-{noIndex && <meta name="robots" content="noindex, nofollow" />}

--- a/src/components/Table.astro
+++ b/src/components/Table.astro
@@ -12,7 +12,7 @@ interface Props {
 const { data, header, widthConfig, ariaLabel } = Astro.props;
 ---
 
-<table aria-label={ariaLabel}>
+<table aria-label={ariaLabel} tabindex="0">
   {
     widthConfig && (
       <colgroup>

--- a/src/components/Table.astro
+++ b/src/components/Table.astro
@@ -14,6 +14,15 @@ const { data, header, widthConfig, ariaLabel } = Astro.props;
 
 <table aria-label={ariaLabel}>
   {
+    widthConfig && (
+      <colgroup>
+        {widthConfig.map(width => (
+          <col class={`col-w-${width.replace('%', '').trim()}`} />
+        ))}
+      </colgroup>
+    )
+  }
+  {
     header && (
       <thead>
         <tr>
@@ -28,8 +37,8 @@ const { data, header, widthConfig, ariaLabel } = Astro.props;
     {
       data.map(row => (
         <tr>
-          {row.map((cell, cellIndex) => (
-            <td style={widthConfig?.[cellIndex] ? `width: ${widthConfig[cellIndex]};` : undefined}>{cell}</td>
+          {row.map(cell => (
+            <td>{cell}</td>
           ))}
         </tr>
       ))

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -26,6 +26,8 @@ const posts = defineCollection({
         title: z.string(),
         description: z.string().optional(),
         date: z.coerce.date(),
+        // Optional last-modified date; surfaces as dateModified / article:modified_time.
+        updatedDate: z.coerce.date().optional(),
         tags: z.array(z.string()).min(1),
         featuredImg: image().optional(),
         featuredImgAlt: z.string().optional(),

--- a/src/data/structured-data.ts
+++ b/src/data/structured-data.ts
@@ -7,6 +7,7 @@ export const STRUCTURED_DATA = {
   person: {
     '@context': 'https://schema.org',
     '@type': 'Person',
+    '@id': `${SITE_METADATA.url}/#person`,
     name: SITE_METADATA.author.name,
     givenName: 'Dawid',
     familyName: 'Ryłko',
@@ -59,5 +60,26 @@ export const STRUCTURED_DATA = {
       email: SITE_METADATA.author.email,
     },
     sameAs: SITE_METADATA.social.map(social => social.url),
+  },
+  // Site-wide WebSite node emitted on every page by the layout. The SearchAction
+  // advertises the blog search to engines (sitelinks searchbox); the publisher
+  // links back to the Person node by @id to avoid duplicating the full object.
+  website: {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    '@id': `${SITE_METADATA.url}/#website`,
+    url: `${SITE_METADATA.url}/`,
+    name: SITE_METADATA.title,
+    description: SITE_METADATA.description.en,
+    inLanguage: ['en', 'pl'],
+    publisher: { '@id': `${SITE_METADATA.url}/#person` },
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: `${SITE_METADATA.url}/blog/?q={search_term_string}`,
+      },
+      'query-input': 'required name=search_term_string',
+    },
   },
 };

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -8,7 +8,9 @@ import Seo from '../components/Seo.astro';
 import Menu from '../components/Menu.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import Bio from '../components/Bio.astro';
+import JsonLd from '../components/JsonLd.astro';
 import { SITE_METADATA } from '../data/site-metadata';
+import { STRUCTURED_DATA } from '../data/structured-data';
 import { GTAG } from '../data/gtag';
 import type { NavLink } from '../types';
 
@@ -20,12 +22,33 @@ interface Props {
   title?: string;
   description?: string;
   image?: string;
+  imageAlt?: string;
+  imageWidth?: number;
+  imageHeight?: number;
   article?: boolean;
+  publishedTime?: string;
+  modifiedTime?: string;
+  tags?: string[];
   noIndex?: boolean;
   lang?: string;
 }
 
-const { breadcrumbTitle, breadcrumbParents, title, description, image, article, noIndex, lang } = Astro.props;
+const {
+  breadcrumbTitle,
+  breadcrumbParents,
+  title,
+  description,
+  image,
+  imageAlt,
+  imageWidth,
+  imageHeight,
+  article,
+  publishedTime,
+  modifiedTime,
+  tags,
+  noIndex,
+  lang,
+} = Astro.props;
 
 const metaLang = lang ?? SITE_METADATA.lang;
 const pathname = Astro.url.pathname;
@@ -34,6 +57,11 @@ const isRootPath = pathname === '/';
 const fakeTitle = '68 97 119 105 100 32 82 121 108 107 111';
 const canonical = new URL(pathname, Astro.site).href;
 const year = new Date().getFullYear();
+
+// Site-wide WebSite node: declares the search box action (sitelinks searchbox)
+// and names the author as publisher. Emitted once per page alongside each page's
+// own WebPage/BlogPosting node.
+const { website } = STRUCTURED_DATA;
 ---
 
 <!doctype html>
@@ -47,15 +75,23 @@ const year = new Date().getFullYear();
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="alternate" type="application/rss+xml" title={SITE_METADATA.title} href="/rss.xml" />
+    <link rel="author" href="/humans.txt" />
     <Seo
       title={title}
       description={description}
       pathname={pathname}
       image={image}
+      imageAlt={imageAlt}
+      imageWidth={imageWidth}
+      imageHeight={imageHeight}
       article={article}
+      publishedTime={publishedTime}
+      modifiedTime={modifiedTime}
+      tags={tags}
       noIndex={noIndex}
       lang={metaLang}
     />
+    <JsonLd data={website} />
 
     {/* Google Analytics 4 — production builds only. */}
     {

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -10,12 +10,13 @@ import Breadcrumbs from '../components/Breadcrumbs.astro';
 import Bio from '../components/Bio.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { GTAG } from '../data/gtag';
+import type { NavLink } from '../types';
 
 // Port of src/components/layout.tsx — the chrome shared by every page (header
 // with menu, main content, breadcrumbs, bio, footer) plus the document <head>.
 interface Props {
   breadcrumbTitle: string;
-  breadcrumbParents?: { name: string; url: string }[];
+  breadcrumbParents?: NavLink[];
   title?: string;
   description?: string;
   image?: string;

--- a/src/lib/blog.test.ts
+++ b/src/lib/blog.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __setEntries, type MockPost } from '../../test/mocks/astro-content';
+import { getBlogPosts, POSTS_PER_PAGE } from './blog';
+
+const post = (id: string, date: string): MockPost => ({ id, data: { date: new Date(date) } });
+
+describe('getBlogPosts', () => {
+  beforeEach(() => __setEntries([]));
+
+  it('returns only top-level entries (drops nested secondary pages)', async () => {
+    __setEntries([post('first-post', '2025-01-01'), post('first-post/ng-help', '2025-01-02')]);
+    const posts = await getBlogPosts();
+    expect(posts.map(p => p.id)).toEqual(['first-post']);
+  });
+
+  it('sorts posts newest first', async () => {
+    __setEntries([post('old', '2024-01-01'), post('new', '2025-06-01'), post('mid', '2024-09-01')]);
+    const posts = await getBlogPosts();
+    expect(posts.map(p => p.id)).toEqual(['new', 'mid', 'old']);
+  });
+});
+
+describe('POSTS_PER_PAGE', () => {
+  it('is a positive integer', () => {
+    expect(Number.isInteger(POSTS_PER_PAGE)).toBe(true);
+    expect(POSTS_PER_PAGE).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { formatPolishDate, toISODate } from './date';
+
+describe('formatPolishDate', () => {
+  it('formats a date in Polish with a long month and zero-padded day', () => {
+    // Local-time constructor keeps the day stable regardless of the host timezone.
+    expect(formatPolishDate(new Date(2025, 11, 26))).toBe('26 grudnia 2025');
+  });
+
+  it('zero-pads single-digit days', () => {
+    expect(formatPolishDate(new Date(2025, 0, 5))).toBe('05 stycznia 2025');
+  });
+});
+
+describe('toISODate', () => {
+  it('returns the ISO 8601 timestamp', () => {
+    expect(toISODate(new Date(Date.UTC(2025, 11, 26, 10, 30)))).toBe('2025-12-26T10:30:00.000Z');
+  });
+});

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,17 @@
+// Centralised date formatting so the blog listing, post pages and the search
+// index render dates identically. Polish locale, long month, zero-padded day —
+// e.g. "26 grudnia 2025".
+const POLISH_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: '2-digit',
+};
+
+export function formatPolishDate(date: Date): string {
+  return date.toLocaleDateString('pl-PL', POLISH_DATE_FORMAT);
+}
+
+// Machine-readable timestamp for JSON-LD / Open Graph (`datePublished`, etc.).
+export function toISODate(date: Date): string {
+  return date.toISOString();
+}

--- a/src/lib/excerpt.test.ts
+++ b/src/lib/excerpt.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { excerpt } from './excerpt';
+
+describe('excerpt', () => {
+  it('returns short plain text unchanged', () => {
+    expect(excerpt('A short sentence.')).toBe('A short sentence.');
+  });
+
+  it('strips fenced code blocks', () => {
+    expect(excerpt('Before\n```js\nconst x = 1;\n```\nAfter')).toBe('Before After');
+  });
+
+  it('strips inline code', () => {
+    expect(excerpt('Use `npm install` to begin.')).toBe('Use to begin.');
+  });
+
+  it('drops images but keeps link text', () => {
+    expect(excerpt('See ![alt](img.png) and [the docs](https://example.com).')).toBe('See and the docs.');
+  });
+
+  it('removes markdown punctuation', () => {
+    expect(excerpt('## Heading **bold** _em_')).toBe('Heading bold em');
+  });
+
+  it('truncates to the requested length on a word boundary and adds an ellipsis', () => {
+    const result = excerpt('one two three four five', 12);
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(13);
+    expect(result).not.toContain('  ');
+  });
+
+  it('does not truncate text exactly at the limit', () => {
+    expect(excerpt('eleven chars', 12)).toBe('eleven chars');
+  });
+});

--- a/src/lib/inline-markdown.test.ts
+++ b/src/lib/inline-markdown.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { inlineMarkdown } from './inline-markdown';
+
+describe('inlineMarkdown', () => {
+  it('renders bold', () => {
+    expect(inlineMarkdown('a **bold** word')).toBe('a <strong>bold</strong> word');
+  });
+
+  it('renders italic with asterisks and underscores', () => {
+    expect(inlineMarkdown('an *em* and _em_')).toBe('an <em>em</em> and <em>em</em>');
+  });
+
+  it('does not treat bold as italic', () => {
+    expect(inlineMarkdown('**strong**')).toBe('<strong>strong</strong>');
+  });
+
+  it('renders code spans and does not reinterpret their contents', () => {
+    expect(inlineMarkdown('run `npm **install**`')).toBe('run <code>npm **install**</code>');
+  });
+
+  it('renders links', () => {
+    expect(inlineMarkdown('[label](https://example.com)')).toBe('<a href="https://example.com">label</a>');
+  });
+
+  it('escapes HTML in the input', () => {
+    expect(inlineMarkdown('a < b & c > d')).toBe('a &lt; b &amp; c &gt; d');
+  });
+
+  it('escapes HTML inside code spans', () => {
+    expect(inlineMarkdown('`<div>`')).toBe('<code>&lt;div&gt;</code>');
+  });
+});

--- a/src/lib/page-metadata.test.ts
+++ b/src/lib/page-metadata.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { createPageSchema } from './page-metadata';
+
+describe('createPageSchema', () => {
+  it('builds a WebPage envelope by default', () => {
+    const schema = createPageSchema({ title: 'Home', description: 'desc' });
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('WebPage');
+    expect(schema.name).toBe('Home');
+    expect(schema.description).toBe('desc');
+  });
+
+  it('defaults the headline to the title and allows an override', () => {
+    expect(createPageSchema({ title: 'Home', description: 'd' }).headline).toBe('Home');
+    expect(createPageSchema({ title: 'Home', description: 'd', headline: 'Custom' }).headline).toBe('Custom');
+  });
+
+  it('joins keywords into a comma-separated string and omits them when absent', () => {
+    expect(createPageSchema({ title: 'T', description: 'd', keywords: ['a', 'b'] }).keywords).toBe('a, b');
+    expect('keywords' in createPageSchema({ title: 'T', description: 'd' })).toBe(false);
+  });
+
+  it('attaches the author Person by default and can opt out', () => {
+    const withAuthor = createPageSchema({ title: 'T', description: 'd' }) as Record<string, unknown>;
+    expect((withAuthor.author as { '@type': string })['@type']).toBe('Person');
+    expect('author' in createPageSchema({ title: 'T', description: 'd', withAuthor: false })).toBe(false);
+  });
+
+  it('supports the CollectionPage type and merges extra fields', () => {
+    const schema = createPageSchema({
+      type: 'CollectionPage',
+      title: 'Files',
+      description: 'd',
+      extra: { mainEntity: { '@type': 'ItemList', numberOfItems: 3 } },
+    }) as Record<string, unknown>;
+    expect(schema['@type']).toBe('CollectionPage');
+    expect((schema.mainEntity as { numberOfItems: number }).numberOfItems).toBe(3);
+  });
+});

--- a/src/lib/page-metadata.ts
+++ b/src/lib/page-metadata.ts
@@ -1,0 +1,44 @@
+import { STRUCTURED_DATA } from '../data/structured-data';
+
+// Factory for the schema.org JSON-LD emitted by static pages. Every page used to
+// hand-roll the same `@context`/`@type`/name/headline/description/keywords/author
+// envelope; this centralises it so only the page-specific parts (about,
+// mainEntity, potentialAction…) are passed in via `extra`.
+const { person } = STRUCTURED_DATA;
+
+type PageSchemaType = 'WebPage' | 'CollectionPage';
+
+interface PageSchemaInput {
+  type?: PageSchemaType;
+  title: string;
+  description: string;
+  // Defaults to `title` when omitted (most pages reuse the title as headline).
+  headline?: string;
+  keywords?: string[];
+  // The author Person is attached by default; pages without an author (e.g. 404)
+  // opt out.
+  withAuthor?: boolean;
+  // Page-specific schema fields merged onto the envelope (about, mainEntity, …).
+  extra?: Record<string, unknown>;
+}
+
+export function createPageSchema({
+  type = 'WebPage',
+  title,
+  description,
+  headline,
+  keywords,
+  withAuthor = true,
+  extra = {},
+}: PageSchemaInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': type,
+    name: title,
+    headline: headline ?? title,
+    description,
+    ...(keywords ? { keywords: keywords.join(', ') } : {}),
+    ...(withAuthor ? { author: person } : {}),
+    ...extra,
+  };
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,10 +1,12 @@
 ---
-import { Picture } from 'astro:assets';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
+import Figure from '../components/Figure.astro';
 import hotDog from '../assets/hot-dog.jpg';
+import { createPageSchema } from '../lib/page-metadata';
+import type { PageMetadata } from '../types';
 
-const PAGE_METADATA = {
+const PAGE_METADATA: PageMetadata = {
   title: 'Page Not Found',
   description: 'The page you are looking for does not exist. Maybe it went out for a hot dog... 🌭',
 };
@@ -14,18 +16,18 @@ const hotDogImage = {
   caption: 'Photo by Dawid Ryłko, taken on September 8, 2017, in Crete, Greece.',
 };
 
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'WebPage',
-  name: PAGE_METADATA.title,
-  headline: PAGE_METADATA.title,
+const structuredData = createPageSchema({
+  title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
-  mainEntity: {
-    '@type': 'CreativeWork',
-    name: '404 Error',
-    description: PAGE_METADATA.description,
+  withAuthor: false,
+  extra: {
+    mainEntity: {
+      '@type': 'CreativeWork',
+      name: '404 Error',
+      description: PAGE_METADATA.description,
+    },
   },
-};
+});
 ---
 
 <PageLayout
@@ -40,9 +42,6 @@ const structuredData = {
   </header>
   <section id="hot-dog" aria-label="Page not found message with hot dog image">
     <p>{PAGE_METADATA.description}</p>
-    <figure style="margin: 0;">
-      <Picture src={hotDog} formats={['avif', 'webp']} layout="full-width" alt={hotDogImage.alt} />
-      <figcaption>{hotDogImage.caption}</figcaption>
-    </figure>
+    <Figure src={hotDog} alt={hotDogImage.alt} caption={hotDogImage.caption} />
   </section>
 </PageLayout>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -95,7 +95,7 @@ const structuredData = {
   </article>
 
   <nav class="blog-post-nav">
-    <ul style="display: flex; flex-wrap: wrap; justify-content: space-between; list-style: none; padding: 0;">
+    <ul>
       <li>
         {
           previous && (

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -30,22 +30,43 @@ export async function getStaticPaths() {
 
 const { post, previous, next } = Astro.props;
 const { Content } = await render(post);
-const { title, description, date, tags, featuredImg, featuredImgAlt } = post.data;
+const { title, description, date, updatedDate, tags, featuredImg, featuredImgAlt } = post.data;
 
 const dateFormatted = formatPolishDate(date);
 const { person } = STRUCTURED_DATA;
 
+const publishedTime = toISODate(date);
+const modifiedTime = updatedDate ? toISODate(updatedDate) : undefined;
+
 // Open Graph wants a bounded image, not the raw (often multi-thousand-px) source.
 const ogImage = featuredImg ? (await getImage({ src: featuredImg, width: 1200, format: 'webp' })).src : undefined;
+// Preserve the source aspect ratio so OG image dimensions are accurate.
+const ogImageWidth = featuredImg ? 1200 : undefined;
+const ogImageHeight = featuredImg ? Math.round((1200 * featuredImg.height) / featuredImg.width) : undefined;
+
+// Approximate word count from the raw Markdown body (strips fenced code first).
+const wordCount = post.body
+  ? post.body
+      .replace(/```[\s\S]*?```/g, ' ')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean).length
+  : undefined;
 
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'BlogPosting',
   headline: title,
   description: description || '',
-  datePublished: toISODate(date),
+  datePublished: publishedTime,
+  dateModified: modifiedTime ?? publishedTime,
   author: person,
+  publisher: { '@id': `${SITE_METADATA.url}/#person` },
   inLanguage: 'pl',
+  keywords: tags.join(', '),
+  articleSection: tags[0],
+  ...(wordCount ? { wordCount } : {}),
+  isPartOf: { '@type': 'Blog', '@id': `${SITE_METADATA.url}/blog/#blog`, name: 'Blog' },
   image: featuredImg ? { '@type': 'ImageObject', url: ogImage, description: featuredImgAlt || '' } : undefined,
   mainEntityOfPage: {
     '@type': 'WebPage',
@@ -60,7 +81,13 @@ const structuredData = {
   title={title}
   description={description || ''}
   image={ogImage}
+  imageAlt={featuredImgAlt}
+  imageWidth={ogImageWidth}
+  imageHeight={ogImageHeight}
   article
+  publishedTime={publishedTime}
+  modifiedTime={modifiedTime}
+  tags={tags}
   lang="pl"
 >
   <JsonLd data={structuredData} />

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -5,6 +5,7 @@ import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
+import { formatPolishDate, toISODate } from '../lib/date';
 
 export async function getStaticPaths() {
   // Replicates Gatsby's createPages exactly: posts ordered by frontmatter date
@@ -31,7 +32,7 @@ const { post, previous, next } = Astro.props;
 const { Content } = await render(post);
 const { title, description, date, tags, featuredImg, featuredImgAlt } = post.data;
 
-const dateFormatted = date.toLocaleDateString('pl-PL', { year: 'numeric', month: 'long', day: '2-digit' });
+const dateFormatted = formatPolishDate(date);
 const { person } = STRUCTURED_DATA;
 
 // Open Graph wants a bounded image, not the raw (often multi-thousand-px) source.
@@ -42,7 +43,7 @@ const structuredData = {
   '@type': 'BlogPosting',
   headline: title,
   description: description || '',
-  datePublished: date.toISOString(),
+  datePublished: toISODate(date),
   author: person,
   inLanguage: 'pl',
   image: featuredImg ? { '@type': 'ImageObject', url: ogImage, description: featuredImgAlt || '' } : undefined,

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -1,13 +1,16 @@
 ---
-import { Picture } from 'astro:assets';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
 import Table from '../components/Table.astro';
+import Figure from '../components/Figure.astro';
+import ExternalLink from '../components/ExternalLink.astro';
 import motto from '../assets/motto.jpg';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
+import { createPageSchema } from '../lib/page-metadata';
+import type { PageMetadata } from '../types';
 
-const PAGE_METADATA = {
+const PAGE_METADATA: PageMetadata = {
   title: 'About',
   description:
     'Meet Dawid Ryłko—a Software Engineer with 10+ years of experience building scalable, secure, and resilient systems. Learn about his professional journey, technical expertise in full-stack development, AI integration, cybersecurity, educational background, and philosophy behind creating meaningful technology.',
@@ -67,40 +70,38 @@ const image = {
 
 const { person } = STRUCTURED_DATA;
 
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'WebPage',
-  name: PAGE_METADATA.title,
-  headline: PAGE_METADATA.title,
+const structuredData = createPageSchema({
+  title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
-  author: person,
-  keywords: PAGE_METADATA.keywords.join(', '),
-  about: {
-    '@type': 'CreativeWork',
-    name: 'Favourite Quote',
-    description: 'Philosophical quotes that inspire approach to technology and software craftsmanship',
-    citation: citations.map(({ authorName, citation, text }) => ({
-      '@type': 'Quotation',
-      text,
-      author: { '@type': 'Person', name: authorName },
-      citation,
-    })),
+  keywords: PAGE_METADATA.keywords,
+  extra: {
+    about: {
+      '@type': 'CreativeWork',
+      name: 'Favourite Quote',
+      description: 'Philosophical quotes that inspire approach to technology and software craftsmanship',
+      citation: citations.map(({ authorName, citation, text }) => ({
+        '@type': 'Quotation',
+        text,
+        author: { '@type': 'Person', name: authorName },
+        citation,
+      })),
+    },
+    mainEntity: {
+      ...person,
+      worksFor: experience.map(([company, , , url]) => ({ '@type': 'Organization', name: company, url: url || '' })),
+      alumniOf: education.map(([institution]) => ({ '@type': 'EducationalOrganization', name: institution })),
+    },
+    potentialAction: {
+      '@type': 'Action',
+      name: 'Download My Full CV',
+      description: 'Download a detailed overview of Dawid Ryłko’s experience and skills in PDF format.',
+      target: [
+        { '@type': 'EntryPoint', urlTemplate: '/resume-en.pdf', actionPlatform: 'https://schema.org/DownloadAction' },
+        { '@type': 'EntryPoint', urlTemplate: '/resume-pl.pdf', actionPlatform: 'https://schema.org/DownloadAction' },
+      ],
+    },
   },
-  mainEntity: {
-    ...person,
-    worksFor: experience.map(([company, , , url]) => ({ '@type': 'Organization', name: company, url: url || '' })),
-    alumniOf: education.map(([institution]) => ({ '@type': 'EducationalOrganization', name: institution })),
-  },
-  potentialAction: {
-    '@type': 'Action',
-    name: 'Download My Full CV',
-    description: 'Download a detailed overview of Dawid Ryłko’s experience and skills in PDF format.',
-    target: [
-      { '@type': 'EntryPoint', urlTemplate: '/resume-en.pdf', actionPlatform: 'https://schema.org/DownloadAction' },
-      { '@type': 'EntryPoint', urlTemplate: '/resume-pl.pdf', actionPlatform: 'https://schema.org/DownloadAction' },
-    ],
-  },
-};
+});
 ---
 
 <PageLayout breadcrumbTitle={PAGE_METADATA.title} title={PAGE_METADATA.title} description={PAGE_METADATA.description}>
@@ -114,15 +115,14 @@ const structuredData = {
       <strong>scalable, secure, and resilient systems</strong>. With{' '}
       <time>over 10 years of professional experience</time> in the <strong>technology industry</strong>, I specialise in
       designing and delivering{' '}
-      <a href="https://silesiansolutions.com/" target="_blank" rel="noopener noreferrer"
-        ><strong>end-to-end digital solutions</strong></a
+      <ExternalLink href="https://silesiansolutions.com/" follow
+        ><strong>end-to-end digital solutions</strong></ExternalLink
       >. From intuitive <strong>frontend experiences</strong> and high-performance <strong>backend systems</strong> to{
         ' '
       }
       <strong>infrastructure automation</strong>, <strong>AI-driven innovation</strong>, and{' '}
-      <a href="https://cyberkatalog.pl/" target="_blank" rel="noopener noreferrer nofollow"
-        ><strong>cybersecurity</strong></a
-      >, I build technology with purpose.
+      <ExternalLink href="https://cyberkatalog.pl/"><strong>cybersecurity</strong></ExternalLink>, I build technology
+      with purpose.
     </p>
     <p>
       My mission is to create <strong>technology that truly matters</strong> - solutions that are <strong
@@ -136,13 +136,13 @@ const structuredData = {
     </p>
     <p>
       You can explore my open-source work on{' '}
-      <a href="https://github.com/dawidrylko" target="_blank" rel="noopener noreferrer nofollow">GitHub</a>, share ideas
-      with me on <a href="https://twitter.com/dawidrylko" target="_blank" rel="noopener noreferrer nofollow">Twitter</a
-      >, or connect professionally on{' '}
-      <a href="https://www.linkedin.com/in/dawidrylko" target="_blank" rel="noopener noreferrer nofollow">LinkedIn</a>.
-      Visit my personal site at{' '}
-      <a href="https://dawid.dev" target="_blank" rel="noopener noreferrer">dawid.dev</a> to see experiments, articles, and
-      insights on technology and software craftsmanship.
+      <ExternalLink href="https://github.com/dawidrylko">GitHub</ExternalLink>, share ideas with me on{' '}
+      <ExternalLink href="https://twitter.com/dawidrylko">Twitter</ExternalLink>, or connect professionally on{' '}
+      <ExternalLink href="https://www.linkedin.com/in/dawidrylko">LinkedIn</ExternalLink>. Visit my personal site at{
+        ' '
+      }
+      <ExternalLink href="https://dawid.dev" follow>dawid.dev</ExternalLink> to see experiments, articles, and insights on
+      technology and software craftsmanship.
     </p>
   </section>
   <section id="philosophy">
@@ -172,10 +172,7 @@ const structuredData = {
       ))
     }
   </section>
-  <figure style="margin: 0;">
-    <Picture src={motto} formats={['avif', 'webp']} layout="full-width" alt={image.alt} />
-    <figcaption>{image.figcaption}</figcaption>
-  </figure>
+  <Figure src={motto} alt={image.alt} caption={image.figcaption} />
   <section id="experience">
     <h2>Experience</h2>
     <Table

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -179,11 +179,17 @@ const structuredData = createPageSchema({
       data={experience.map(([company, position, duration]) => [company, position, duration])}
       header={['Company', 'Position', 'Duration']}
       widthConfig={['35%', '35%', '30%']}
+      ariaLabel="Professional experience"
     />
   </section>
   <section id="education">
     <h2>Education</h2>
-    <Table data={education} header={['Institution', 'Degree', 'Field of Study']} widthConfig={['35%', '35%', '30%']} />
+    <Table
+      data={education}
+      header={['Institution', 'Degree', 'Field of Study']}
+      widthConfig={['35%', '35%', '30%']}
+      ariaLabel="Education"
+    />
   </section>
   <section id="download">
     <h2>Download My Full CV</h2>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -10,6 +10,7 @@ import { STRUCTURED_DATA } from '../../data/structured-data';
 import { excerpt } from '../../lib/excerpt';
 import { inlineMarkdown } from '../../lib/inline-markdown';
 import { getBlogPosts, POSTS_PER_PAGE } from '../../lib/blog';
+import { formatPolishDate, toISODate } from '../../lib/date';
 
 const PAGE_METADATA = {
   title: 'Blog 🇵🇱',
@@ -48,7 +49,7 @@ const { person } = STRUCTURED_DATA;
 const items = page.data.map(post => {
   const description = post.data.description || excerpt(post.body ?? '');
   const descriptionHtml = inlineMarkdown(description);
-  const dateFormatted = post.data.date.toLocaleDateString('pl-PL', { year: 'numeric', month: 'long', day: '2-digit' });
+  const dateFormatted = formatPolishDate(post.data.date);
   return { post, description, descriptionHtml, dateFormatted };
 });
 
@@ -71,7 +72,7 @@ const structuredData = {
     '@type': 'BlogPosting',
     headline: post.data.title,
     description,
-    datePublished: post.data.date.toISOString(),
+    datePublished: toISODate(post.data.date),
     author: { '@type': 'Person', name: author.name },
     image: post.data.featuredImg
       ? { '@type': 'ImageObject', url: post.data.featuredImg.src, description: post.data.featuredImgAlt || '' }

--- a/src/pages/blog/search.json.ts
+++ b/src/pages/blog/search.json.ts
@@ -2,6 +2,7 @@ import { getImage } from 'astro:assets';
 import { getBlogPosts } from '../../lib/blog';
 import { excerpt } from '../../lib/excerpt';
 import { inlineMarkdown } from '../../lib/inline-markdown';
+import { formatPolishDate } from '../../lib/date';
 
 // Static search index consumed by the client-side blog search. Covers every
 // listed post so search spans the whole archive, not just the current page.
@@ -27,7 +28,7 @@ export async function GET() {
         description: plainDescription,
         descriptionHtml: inlineMarkdown(plainDescription),
         tags,
-        dateFormatted: date.toLocaleDateString('pl-PL', { year: 'numeric', month: 'long', day: '2-digit' }),
+        dateFormatted: formatPolishDate(date),
         url: `/${post.id}/`,
         ...(img ? { img } : {}),
       };

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,10 +1,13 @@
 ---
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
+import ExternalLink from '../components/ExternalLink.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
+import { createPageSchema } from '../lib/page-metadata';
+import type { PageMetadata } from '../types';
 
-const PAGE_METADATA = {
+const PAGE_METADATA: PageMetadata = {
   title: 'Contact',
   description:
     'Get in touch with Dawid Ryłko for software engineering projects, system architecture consulting, and technology collaboration. Available for scalable, secure, and future-proof solutions across the full technology stack—from frontend to backend, cloud infrastructure, AI integration, and cybersecurity.',
@@ -24,16 +27,12 @@ const author = SITE_METADATA.author;
 const social = SITE_METADATA.social;
 const { person } = STRUCTURED_DATA;
 
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'WebPage',
-  name: PAGE_METADATA.title,
-  headline: PAGE_METADATA.title,
+const structuredData = createPageSchema({
+  title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
-  keywords: PAGE_METADATA.keywords.join(', '),
-  author: person,
-  mainEntity: person,
-};
+  keywords: PAGE_METADATA.keywords,
+  extra: { mainEntity: person },
+});
 ---
 
 <PageLayout breadcrumbTitle={PAGE_METADATA.title} title={PAGE_METADATA.title} description={PAGE_METADATA.description}>
@@ -77,14 +76,9 @@ const structuredData = {
           .filter(({ name }) => ['GitHub', 'Twitter', 'Linkedin'].includes(name))
           .map(({ name, url, follow }) => (
             <li>
-              <a
-                href={url}
-                target="_blank"
-                rel={follow ? 'noopener noreferrer' : 'noopener noreferrer nofollow'}
-                title={`Find Dawid Ryłko on ${name}`}
-              >
+              <ExternalLink href={url} follow={follow} title={`Find Dawid Ryłko on ${name}`}>
                 {name}
-              </a>
+              </ExternalLink>
             </li>
           ))
       }

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -195,6 +195,14 @@ const structuredData = createPageSchema({
     <section aria-labelledby="presentations-heading">
       <h2 id="presentations-heading">Presentations</h2>
       <table class="presentations-table" data-presentations>
+        <colgroup>
+          <col class="col-w-5" />
+          <col class="col-w-20" />
+          <col class="col-w-20" />
+          <col class="col-w-10" />
+          <col class="col-w-15" />
+          <col class="col-w-30" />
+        </colgroup>
         <thead>
           <tr>
             <th scope="col">#</th>
@@ -209,13 +217,13 @@ const structuredData = createPageSchema({
           {
             rows.map(row => (
               <tr>
-                <td style="width: 5%;">{row.index}</td>
-                <td style="width: 20%;">{row.topic}</td>
-                <td style="width: 20%;">{row.title}</td>
-                <td style="width: 10%;">{row.language}</td>
-                <td style="width: 15%;">{row.size}</td>
-                <td style="width: 30%;">
-                  <div style="display: flex; align-items: center; gap: 0.5rem;">
+                <td>{row.index}</td>
+                <td>{row.topic}</td>
+                <td>{row.title}</td>
+                <td>{row.language}</td>
+                <td>{row.size}</td>
+                <td>
+                  <div class="file-actions">
                     {row.links.map(link =>
                       link.action === 'open' ? (
                         <a

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
-import { STRUCTURED_DATA } from '../data/structured-data';
+import { createPageSchema } from '../lib/page-metadata';
+import type { PageMetadata } from '../types';
 
 // Replaces Gatsby's custom `StaticFile` sourceNodes: read the same static/files
 // tree from disk at build time. publicDir ('../static') serves these at /files.
@@ -140,7 +141,7 @@ const rows = sortedEntries
   })
   .filter((row): row is NonNullable<typeof row> => row !== null);
 
-const PAGE_METADATA = {
+const PAGE_METADATA: PageMetadata = {
   title: 'Files',
   description:
     'Browse and download technical presentations, slides, and educational materials by Dawid Ryłko. Access professionally crafted resources covering software development, Node.js, TypeScript, and modern web technologies—available in multiple formats and languages.',
@@ -156,35 +157,33 @@ const PAGE_METADATA = {
   ],
 };
 
-const { person } = STRUCTURED_DATA;
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'CollectionPage',
-  name: PAGE_METADATA.title,
-  headline: PAGE_METADATA.title,
+const structuredData = createPageSchema({
+  type: 'CollectionPage',
+  title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
-  author: person,
-  keywords: PAGE_METADATA.keywords.join(', '),
-  about: [
-    {
-      '@type': 'Thing',
-      name: 'Technical Presentations',
-      description:
-        'Educational materials and technical presentations covering software development, programming languages, and web technologies.',
+  keywords: PAGE_METADATA.keywords,
+  extra: {
+    about: [
+      {
+        '@type': 'Thing',
+        name: 'Technical Presentations',
+        description:
+          'Educational materials and technical presentations covering software development, programming languages, and web technologies.',
+      },
+      {
+        '@type': 'Thing',
+        name: 'Educational Resources',
+        description: 'Professional learning materials for developers and technology enthusiasts.',
+      },
+    ],
+    mainEntity: {
+      '@type': 'ItemList',
+      name: 'Presentation Files',
+      description: 'Collection of downloadable technical presentations and educational materials',
+      numberOfItems: grouped.size,
     },
-    {
-      '@type': 'Thing',
-      name: 'Educational Resources',
-      description: 'Professional learning materials for developers and technology enthusiasts.',
-    },
-  ],
-  mainEntity: {
-    '@type': 'ItemList',
-    name: 'Presentation Files',
-    description: 'Collection of downloadable technical presentations and educational materials',
-    numberOfItems: grouped.size,
   },
-};
+});
 ---
 
 <PageLayout breadcrumbTitle={PAGE_METADATA.title} title={PAGE_METADATA.title} description={PAGE_METADATA.description}>

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -194,7 +194,7 @@ const structuredData = createPageSchema({
   <main>
     <section aria-labelledby="presentations-heading">
       <h2 id="presentations-heading">Presentations</h2>
-      <table class="presentations-table" data-presentations>
+      <table class="presentations-table" data-presentations aria-label="Presentations" tabindex="0">
         <colgroup>
           <col class="col-w-5" />
           <col class="col-w-20" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,8 +2,10 @@
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
 import { STRUCTURED_DATA } from '../data/structured-data';
+import { createPageSchema } from '../lib/page-metadata';
+import type { PageMetadata } from '../types';
 
-const PAGE_METADATA = {
+const PAGE_METADATA: PageMetadata = {
   title: 'Home',
   description:
     'Dawid Ryłko - Software Engineer specializing in scalable, secure, and resilient systems. Explore articles on software engineering, system architecture, and emerging technologies. Available for collaboration on meaningful technology projects.',
@@ -20,21 +22,21 @@ const PAGE_METADATA = {
 };
 
 const { person } = STRUCTURED_DATA;
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'WebPage',
-  name: PAGE_METADATA.title,
+const structuredData = createPageSchema({
+  title: PAGE_METADATA.title,
   headline: 'Dawid Ryłko - Software Engineer',
   description: PAGE_METADATA.description,
-  keywords: PAGE_METADATA.keywords.join(', '),
-  author: person,
-  about: {
-    '@type': 'Thing',
-    name: 'Software Engineering',
-    description: 'Designing and building scalable, secure, and future-proof systems that address real-world challenges',
+  keywords: PAGE_METADATA.keywords,
+  extra: {
+    about: {
+      '@type': 'Thing',
+      name: 'Software Engineering',
+      description:
+        'Designing and building scalable, secure, and future-proof systems that address real-world challenges',
+    },
+    mainEntity: person,
   },
-  mainEntity: person,
-};
+});
 ---
 
 <PageLayout breadcrumbTitle={PAGE_METADATA.title}>

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -82,13 +82,14 @@ const structuredData = createPageSchema({
     <section id="site-info" aria-label="Site Information">
       <h2>Site Information</h2>
       <table>
+        <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
         <thead><tr><th scope="col">Property</th><th scope="col">Value</th></tr></thead>
         <tbody>
           {
             siteInfo.map(([prop, value]) => (
               <tr>
-                <td style="width: 30%;">{prop}</td>
-                <td style="width: 70%;">{value}</td>
+                <td>{prop}</td>
+                <td>{value}</td>
               </tr>
             ))
           }
@@ -98,13 +99,14 @@ const structuredData = createPageSchema({
     <section id="pages" aria-label="Pages">
       <h2>Pages</h2>
       <table>
+        <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
         <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
         <tbody>
           {
             staticPages.map((p, i) => (
               <tr>
-                <td style="width: 10%;">{i + 1}</td>
-                <td style="width: 90%;">
+                <td>{i + 1}</td>
+                <td>
                   <a href={p}>{p}</a>
                 </td>
               </tr>
@@ -116,13 +118,14 @@ const structuredData = createPageSchema({
     <section id="blog-posts" aria-label="Blog Posts">
       <h2>Blog Posts</h2>
       <table>
+        <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
         <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
         <tbody>
           {
             blogPaths.map((p, i) => (
               <tr>
-                <td style="width: 10%;">{i + 1}</td>
-                <td style="width: 90%;">
+                <td>{i + 1}</td>
+                <td>
                   <a href={p}>{p}</a>
                 </td>
               </tr>

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -3,7 +3,8 @@ import { getCollection } from 'astro:content';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
 import { SITE_METADATA } from '../data/site-metadata';
-import { STRUCTURED_DATA } from '../data/structured-data';
+import { createPageSchema } from '../lib/page-metadata';
+import type { PageMetadata } from '../types';
 
 // Static (non-blog) routes provided by src/pages. The Gatsby version queried
 // allSitePage; here the set is explicit since it changes rarely.
@@ -28,7 +29,7 @@ const siteInfo: [string, string][] = [
   ['Blog posts', blogPaths.length.toString()],
 ];
 
-const PAGE_METADATA = {
+const PAGE_METADATA: PageMetadata = {
   title: 'Metadata',
   description:
     'Technical metadata and comprehensive site statistics for dawidrylko.com. View build information, content inventory, page structure, and blog post directory—complete transparency into website architecture and content organization.',
@@ -44,34 +45,32 @@ const PAGE_METADATA = {
   ],
 };
 
-const { person } = STRUCTURED_DATA;
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'CollectionPage',
-  name: PAGE_METADATA.title,
-  headline: PAGE_METADATA.title,
+const structuredData = createPageSchema({
+  type: 'CollectionPage',
+  title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
-  author: person,
-  keywords: PAGE_METADATA.keywords.join(', '),
-  about: [
-    {
-      '@type': 'Thing',
-      name: 'Site Information',
-      description: 'Technical metadata including build time, content statistics, and website configuration details.',
+  keywords: PAGE_METADATA.keywords,
+  extra: {
+    about: [
+      {
+        '@type': 'Thing',
+        name: 'Site Information',
+        description: 'Technical metadata including build time, content statistics, and website configuration details.',
+      },
+      {
+        '@type': 'Thing',
+        name: 'Content Structure',
+        description: 'Complete inventory of static pages and blog posts with navigation paths.',
+      },
+    ],
+    mainEntity: {
+      '@type': 'ItemList',
+      name: 'Site Content Inventory',
+      description: 'Complete list of all pages and blog posts on the website',
+      numberOfItems: staticPages.length + blogPaths.length,
     },
-    {
-      '@type': 'Thing',
-      name: 'Content Structure',
-      description: 'Complete inventory of static pages and blog posts with navigation paths.',
-    },
-  ],
-  mainEntity: {
-    '@type': 'ItemList',
-    name: 'Site Content Inventory',
-    description: 'Complete list of all pages and blog posts on the website',
-    numberOfItems: staticPages.length + blogPaths.length,
   },
-};
+});
 ---
 
 <PageLayout breadcrumbTitle={PAGE_METADATA.title} title={PAGE_METADATA.title} description={PAGE_METADATA.description}>

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -81,7 +81,7 @@ const structuredData = createPageSchema({
   <main>
     <section id="site-info" aria-label="Site Information">
       <h2>Site Information</h2>
-      <table>
+      <table aria-label="Site information" tabindex="0">
         <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
         <thead><tr><th scope="col">Property</th><th scope="col">Value</th></tr></thead>
         <tbody>
@@ -98,7 +98,7 @@ const structuredData = createPageSchema({
     </section>
     <section id="pages" aria-label="Pages">
       <h2>Pages</h2>
-      <table>
+      <table aria-label="Pages" tabindex="0">
         <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
         <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
         <tbody>
@@ -117,7 +117,7 @@ const structuredData = createPageSchema({
     </section>
     <section id="blog-posts" aria-label="Blog Posts">
       <h2>Blog Posts</h2>
-      <table>
+      <table aria-label="Blog posts" tabindex="0">
         <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
         <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
         <tbody>

--- a/src/pages/setup.astro
+++ b/src/pages/setup.astro
@@ -182,13 +182,14 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
     <section id="desktop" aria-labelledby="desktop-heading">
       <h2 id="desktop-heading">Desktop Setup</h2>
       <table aria-label="Desktop hardware and equipment specifications">
+        <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
         <thead><tr><th scope="col">Type</th><th scope="col">Full Name</th></tr></thead>
         <tbody>
           {
             desktopSetup.map(([type, name, link, details]) => (
               <tr>
-                <td style="width: 30%;">{type}</td>
-                <td style="width: 70%;">
+                <td>{type}</td>
+                <td>
                   {link ? (
                     <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
                       {name}
@@ -218,6 +219,12 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
           <section id={id} aria-labelledby={`${id}-heading`}>
             <h2 id={`${id}-heading`}>{heading}</h2>
             <table aria-label={ariaLabel}>
+              <colgroup>
+                <>
+                  <col class="col-w-30" />
+                  <col class="col-w-70" />
+                </>
+              </colgroup>
               <thead>
                 <tr>
                   <>
@@ -229,8 +236,8 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
               <tbody>
                 {items.map(([type, name, link, details]) => (
                   <tr>
-                    <td style="width: 30%;">{type}</td>
-                    <td style="width: 70%;">
+                    <td>{type}</td>
+                    <td>
                       {link ? (
                         <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
                           {name}

--- a/src/pages/setup.astro
+++ b/src/pages/setup.astro
@@ -181,7 +181,7 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
   <main>
     <section id="desktop" aria-labelledby="desktop-heading">
       <h2 id="desktop-heading">Desktop Setup</h2>
-      <table aria-label="Desktop hardware and equipment specifications">
+      <table aria-label="Desktop hardware and equipment specifications" tabindex="0">
         <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
         <thead><tr><th scope="col">Type</th><th scope="col">Full Name</th></tr></thead>
         <tbody>
@@ -218,7 +218,7 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
         .map(({ id, heading, ariaLabel, items }) => (
           <section id={id} aria-labelledby={`${id}-heading`}>
             <h2 id={`${id}-heading`}>{heading}</h2>
-            <table aria-label={ariaLabel}>
+            <table aria-label={ariaLabel} tabindex="0">
               <colgroup>
                 <>
                   <col class="col-w-30" />

--- a/src/pages/setup.astro
+++ b/src/pages/setup.astro
@@ -1,10 +1,12 @@
 ---
-import { Picture } from 'astro:assets';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
+import Figure from '../components/Figure.astro';
+import ExternalLink from '../components/ExternalLink.astro';
 import Mermaid from '../components/Mermaid.tsx';
 import hardwareSetup from '../assets/hardware-setup.jpg';
-import { STRUCTURED_DATA } from '../data/structured-data';
+import { createPageSchema } from '../lib/page-metadata';
+import type { PageMetadata } from '../types';
 
 type SetupItem = [type: string, name: string, link?: string, details?: string];
 
@@ -60,7 +62,7 @@ const image = {
   figcaption: `Photo by Dawid Ryłko, taken on January 3, 2026.`,
 };
 
-const PAGE_METADATA = {
+const PAGE_METADATA: PageMetadata = {
   title: 'Setup',
   description:
     "Discover Dawid Ryłko's professional development workstation with segmented hardware stations and connection graph. Includes Mac mini M4 setup, ultrawide monitor, KVM switching, NAS storage and acoustic guitar equipment.",
@@ -120,41 +122,39 @@ const setupDiagram = `graph TD
   Monitor -- "USB-A ↔ USB-C<br/><small>Light Bar cable</small>" --> Lightbar
 `;
 
-const { person } = STRUCTURED_DATA;
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'CollectionPage',
-  name: PAGE_METADATA.title,
-  headline: PAGE_METADATA.title,
+const structuredData = createPageSchema({
+  type: 'CollectionPage',
+  title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
-  author: person,
-  keywords: PAGE_METADATA.keywords.join(', '),
-  about: [
-    {
-      '@type': 'Thing',
-      name: 'Development Workstation',
-      description:
-        'Segmented hardware setup with device stations, KVM switching, ultrawide monitor and enterprise-grade NAS storage.',
+  keywords: PAGE_METADATA.keywords,
+  extra: {
+    about: [
+      {
+        '@type': 'Thing',
+        name: 'Development Workstation',
+        description:
+          'Segmented hardware setup with device stations, KVM switching, ultrawide monitor and enterprise-grade NAS storage.',
+      },
+      {
+        '@type': 'Thing',
+        name: 'Hardware Topology',
+        description:
+          'Connection graph presenting data, video and power paths between computers, hub, KVM, monitor and peripherals.',
+      },
+      {
+        '@type': 'Thing',
+        name: 'Guitar Setup',
+        description: 'Acoustic guitar equipment with amplifier and accessories for recording and practice.',
+      },
+    ],
+    mainEntity: {
+      '@type': 'ItemList',
+      name: 'Equipment Collection',
+      description: 'Desktop hardware, peripherals, network storage and music equipment',
+      numberOfItems: desktopSetup.length + additionalEquipment.length + guitarSetup.length,
     },
-    {
-      '@type': 'Thing',
-      name: 'Hardware Topology',
-      description:
-        'Connection graph presenting data, video and power paths between computers, hub, KVM, monitor and peripherals.',
-    },
-    {
-      '@type': 'Thing',
-      name: 'Guitar Setup',
-      description: 'Acoustic guitar equipment with amplifier and accessories for recording and practice.',
-    },
-  ],
-  mainEntity: {
-    '@type': 'ItemList',
-    name: 'Equipment Collection',
-    description: 'Desktop hardware, peripherals, network storage and music equipment',
-    numberOfItems: desktopSetup.length + additionalEquipment.length + guitarSetup.length,
   },
-};
+});
 
 const sections: { id: string; heading: string; ariaLabel: string; items: SetupItem[] }[] = [
   {
@@ -190,14 +190,9 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
                 <td style="width: 30%;">{type}</td>
                 <td style="width: 70%;">
                   {link ? (
-                    <a
-                      href={link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label={`View ${name} on external site`}
-                    >
+                    <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
                       {name}
-                    </a>
+                    </ExternalLink>
                   ) : (
                     name
                   )}
@@ -214,10 +209,7 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
       <Mermaid client:load chart={setupDiagram} ariaLabel="Hardware setup workflow diagram" />
     </section>
 
-    <figure style="margin: 0;">
-      <Picture src={hardwareSetup} formats={['avif', 'webp']} layout="full-width" alt={image.alt} />
-      <figcaption>{image.figcaption}</figcaption>
-    </figure>
+    <Figure src={hardwareSetup} alt={image.alt} caption={image.figcaption} />
 
     {
       sections
@@ -240,14 +232,9 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
                     <td style="width: 30%;">{type}</td>
                     <td style="width: 70%;">
                       {link ? (
-                        <a
-                          href={link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={`View ${name} on external site`}
-                        >
+                        <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
                           {name}
-                        </a>
+                        </ExternalLink>
                       ) : (
                         name
                       )}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -349,6 +349,12 @@ table tr:nth-child(even) {
   display: inline;
 }
 
+/* Figure */
+
+.figure {
+  margin: 0;
+}
+
 /* Link */
 
 a {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -81,6 +81,14 @@
   }
 }
 
+/* Responsive strategy: mobile-first. Base rules target the smallest screen and
+   `min-width` media queries layer on enhancements for larger viewports. CSS
+   custom properties cannot be used inside @media, so the breakpoint scale is a
+   documented convention — keep these literal values in sync:
+     sm = 30rem  (480px)  — large phones and up
+     md = 48rem  (768px)  — tablets and up
+   Headings use clamp() for fluid scaling instead of stepped breakpoints. */
+
 /* HTML elements */
 
 *,
@@ -142,22 +150,25 @@ h6 {
   color: var(--color-heading);
 }
 
+/* Fluid headings: scale smoothly between the previous small-screen and desktop
+   sizes. clamp()'s min/max anchor the extremes to the old stepped values, so the
+   smallest and largest viewports render as before; only mid-range is fluid. */
 h1 {
   font-weight: var(--fontWeight-black);
-  font-size: var(--fontSize-6);
+  font-size: clamp(1.44rem, 0.69rem + 3.74vw, 2.488rem);
   color: var(--color-heading-black);
 }
 
 h2 {
-  font-size: var(--fontSize-5);
+  font-size: clamp(1.2rem, 0.575rem + 3.12vw, 2.074rem);
 }
 
 h3 {
-  font-size: var(--fontSize-4);
+  font-size: clamp(1rem, 0.48rem + 2.6vw, 1.728rem);
 }
 
 h4 {
-  font-size: var(--fontSize-3);
+  font-size: clamp(1rem, 0.686rem + 1.57vw, 1.44rem);
 }
 
 h5 {
@@ -166,42 +177,6 @@ h5 {
 
 h6 {
   font-size: var(--fontSize-1);
-}
-
-@media (width <= 768px) {
-  h1 {
-    font-size: var(--fontSize-5);
-  }
-
-  h2 {
-    font-size: var(--fontSize-4);
-  }
-
-  h3 {
-    font-size: var(--fontSize-3);
-  }
-
-  h4 {
-    font-size: var(--fontSize-2);
-  }
-}
-
-@media (width <= 480px) {
-  h1 {
-    font-size: var(--fontSize-4);
-  }
-
-  h2 {
-    font-size: var(--fontSize-3);
-  }
-
-  h3 {
-    font-size: var(--fontSize-2);
-  }
-
-  h4 {
-    font-size: var(--fontSize-1);
-  }
 }
 
 h1 > a {
@@ -340,6 +315,49 @@ table tr:nth-child(even) {
   background-color: var(--color-accent);
 }
 
+/* Column width hints applied to <col> elements so width values stay out of
+   inline styles. Tables scroll horizontally on small screens (table is
+   display: block; overflow-x: auto above), so these only shape proportions
+   where there is room. */
+.col-w-5 {
+  width: 5%;
+}
+
+.col-w-10 {
+  width: 10%;
+}
+
+.col-w-15 {
+  width: 15%;
+}
+
+.col-w-20 {
+  width: 20%;
+}
+
+.col-w-30 {
+  width: 30%;
+}
+
+.col-w-35 {
+  width: 35%;
+}
+
+.col-w-70 {
+  width: 70%;
+}
+
+.col-w-90 {
+  width: 90%;
+}
+
+/* Download actions cell on the files page: keep icons in a row. */
+.file-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
 /* Files page: Keynote/PowerPoint download variants are hidden until the
    cmd/ctrl+shift+. shortcut adds .show-hidden-variants to the table. */
 .presentations-table .file-link.is-hidden-variant {
@@ -377,9 +395,15 @@ a:focus {
 .global-wrapper {
   margin: var(--spacing-0) auto;
   max-width: var(--maxWidth-wrapper);
-  padding: var(--spacing-10) var(--spacing-5);
+  padding: var(--spacing-8) var(--spacing-4);
   overflow-x: hidden;
   overflow-wrap: break-word;
+}
+
+@media (width >= 48rem) {
+  .global-wrapper {
+    padding: var(--spacing-10) var(--spacing-5);
+  }
 }
 
 .post-list-item {
@@ -403,7 +427,7 @@ a:focus {
 }
 
 /* Mobile-first post card: thumbnail stacks above the excerpt, then sits beside
-   it from 600px up. */
+   it from the sm breakpoint up. */
 .post-list-item section {
   display: flex;
   flex-direction: column;
@@ -427,7 +451,7 @@ a:focus {
   object-fit: cover;
 }
 
-@media screen and (width >= 600px) {
+@media (width >= 30rem) {
   .post-list-item section {
     flex-direction: row;
     align-items: center;
@@ -444,16 +468,19 @@ a:focus {
   }
 }
 
+/* Mobile-first author card: stacked and centred on phones; horizontal from the
+   sm breakpoint up. */
 .bio {
   display: flex;
+  flex-direction: column;
   align-items: center;
   margin-top: var(--spacing-10);
   margin-bottom: var(--spacing-10);
 }
 
 .bio .avatar {
-  margin-right: var(--spacing-4);
-  margin-bottom: var(--spacing-0);
+  margin-right: var(--spacing-0);
+  margin-bottom: var(--spacing-4);
   min-width: 60px;
   border-radius: 100%;
 }
@@ -461,65 +488,60 @@ a:focus {
 .bio .name {
   font-weight: var(--fontWeight-bold);
   margin-bottom: var(--spacing-0);
+  text-align: center;
 }
 
 .bio .job-title {
   font-size: var(--fontSize-0);
   margin-bottom: var(--spacing-0);
+  text-align: center;
 }
 
 .bio ul {
   font-size: var(--fontSize-0);
   margin: var(--spacing-0);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1);
+  justify-content: center;
 }
 
 .bio ul li {
-  display: inline;
+  display: inline-flex;
+  margin: 0;
 }
 
 .bio ul li:not(:last-child)::after {
-  content: '•';
+  content: '';
   margin: 0 var(--spacing-1);
 }
 
-/* Media queries */
-@media screen and (width <= 600px) {
+@media (width >= 30rem) {
   .bio {
+    flex-direction: row;
     align-items: center;
-    flex-direction: column;
   }
 
   .bio .avatar {
-    margin-bottom: var(--spacing-4);
+    margin-right: var(--spacing-4);
+    margin-bottom: var(--spacing-0);
   }
 
-  .bio .name {
-    text-align: center;
-  }
-
+  .bio .name,
   .bio .job-title {
-    text-align: center;
+    text-align: left;
   }
 
   .bio ul {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-1);
-    justify-content: center;
+    display: block;
   }
 
   .bio ul li {
-    display: inline-flex;
-    margin: 0;
+    display: inline;
   }
 
   .bio ul li:not(:last-child)::after {
-    content: '';
-    margin: 0 var(--spacing-1);
-  }
-
-  .global-wrapper {
-    padding: var(--spacing-8) var(--spacing-4);
+    content: '•';
   }
 }
 
@@ -530,7 +552,7 @@ a:focus {
 .header-title {
   font-weight: var(--fontWeight-bold);
   font-family: var(--font-heading);
-  font-size: var(--fontSize-4);
+  font-size: clamp(1.2rem, 0.823rem + 1.89vw, 1.728rem);
   display: block;
   margin-bottom: var(--spacing-4);
   color: var(--color-heading-black);
@@ -574,8 +596,14 @@ a:focus {
   margin-bottom: var(--spacing-8);
 }
 
+/* Previous/next post navigation: spread the two links across the row. */
 .blog-post-nav ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  list-style: none;
   margin: var(--spacing-0);
+  padding: var(--spacing-0);
 }
 
 .rss {
@@ -744,42 +772,17 @@ a:focus {
 
 /* Media queries */
 
-@media (width <= 42rem) {
+/* From the md breakpoint up, prose lists pull their markers into the gutter and
+   blockquotes hang into the left margin. */
+@media (width >= 48rem) {
   blockquote {
-    padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-4);
-    margin-left: var(--spacing-0);
+    margin-left: calc(-1 * var(--spacing-6));
+    padding-left: var(--spacing-6);
   }
 
   ul,
   ol {
-    list-style-position: inside;
-  }
-
-  .header-title {
-    font-size: var(--fontSize-3);
-  }
-}
-
-/* Extra small devices */
-@media (width <= 320px) {
-  .global-wrapper {
-    padding: var(--spacing-6) var(--spacing-3);
-  }
-
-  .header-title {
-    font-size: var(--fontSize-2);
-  }
-
-  h1 {
-    font-size: var(--fontSize-3);
-  }
-
-  h2 {
-    font-size: var(--fontSize-2);
-  }
-
-  h3 {
-    font-size: var(--fontSize-1);
+    list-style-position: outside;
   }
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -28,11 +28,11 @@
   --spacing-24: 6rem;
   --spacing-32: 8rem;
   --fontFamily-sans:
-    'MontserratVariable', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
+    'MontserratVariable', system-ui, -apple-system, blinkmacsystemfont,
+    'Segoe UI', roboto, 'Helvetica Neue', arial, 'Noto Sans', sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --fontFamily-serif:
-    'Merriweather', 'Georgia', Cambria, 'Times New Roman', Times, serif;
+    'Merriweather', 'Georgia', cambria, 'Times New Roman', times, serif;
   --font-body: var(--fontFamily-serif);
   --font-heading: var(--fontFamily-sans);
   --fontWeight-normal: 400;
@@ -43,6 +43,7 @@
   --lineHeight-tight: 1.1;
   --lineHeight-normal: 1.5;
   --lineHeight-relaxed: 1.625;
+
   /* 1.200 Minor Third Type Scale */
   --fontSize-0: 0.833rem;
   --fontSize-1: 1rem;
@@ -58,9 +59,10 @@
   --color-heading: #1a202c;
   --color-heading-black: black;
   --color-accent: #d1dce5;
-  --color-background: #ffffff;
+  --color-background: #fff;
+
   /* Text rendered on top of --color-primary (e.g. table headers). */
-  --color-on-primary: #ffffff;
+  --color-on-primary: #fff;
 }
 
 /* Dark theme: pure CSS, driven by the OS setting. Only the color tokens are
@@ -72,7 +74,7 @@
     --color-text: #d8dee9;
     --color-text-light: #a6b1c2;
     --color-heading: #f0f3f8;
-    --color-heading-black: #ffffff;
+    --color-heading-black: #fff;
     --color-accent: #2a3340;
     --color-background: #1a1f27;
     --color-on-primary: #0b1f33;
@@ -82,8 +84,8 @@
 /* HTML elements */
 
 *,
-:after,
-:before {
+::after,
+::before {
   box-sizing: border-box;
 }
 
@@ -104,7 +106,7 @@ body {
   color: var(--color-text);
   background: var(--color-background);
   overflow-x: hidden;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   hyphens: auto;
 }
 
@@ -127,9 +129,8 @@ h6 {
   margin-bottom: var(--spacing-6);
   line-height: var(--lineHeight-tight);
   letter-spacing: -0.025em;
-  word-wrap: break-word;
-  hyphens: auto;
   overflow-wrap: break-word;
+  hyphens: auto;
 }
 
 h2,
@@ -167,7 +168,7 @@ h6 {
   font-size: var(--fontSize-1);
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   h1 {
     font-size: var(--fontSize-5);
   }
@@ -185,7 +186,7 @@ h6 {
   }
 }
 
-@media (max-width: 480px) {
+@media (width <= 480px) {
   h1 {
     font-size: var(--fontSize-4);
   }
@@ -221,11 +222,12 @@ h6 > a {
 
 p {
   line-height: var(--lineHeight-relaxed);
+
   --baseline-multiplier: 0.179;
   --x-height-multiplier: 0.35;
+
   margin: var(--spacing-0) var(--spacing-0) var(--spacing-8) var(--spacing-0);
   padding: var(--spacing-0);
-  word-wrap: break-word;
   overflow-wrap: break-word;
 }
 
@@ -240,18 +242,22 @@ code {
 }
 
 table {
-  overflow-x: auto;
   display: block;
+  overflow-x: auto;
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--spacing-8);
+  font-size: var(--fontSize-0);
   white-space: nowrap;
 }
 
 pre {
   overflow-x: auto;
-  word-wrap: normal;
+  overflow-wrap: normal;
 }
 
 code {
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 ul,
@@ -290,6 +296,7 @@ li > ul {
 .blog-post section ul,
 .blog-post section ol {
   padding-left: var(--spacing-6);
+
   /* Keep markers in the gutter beside the text. Without this, the mobile
      `list-style-position: inside` rule below drops the marker onto its own line
      above loose (<li><p>…</p>) items. */
@@ -305,6 +312,7 @@ blockquote {
   font-size: var(--fontSize-2);
   font-style: italic;
   margin-bottom: var(--spacing-8);
+  overflow: auto;
 }
 
 blockquote > :last-child {
@@ -314,13 +322,6 @@ blockquote > :last-child {
 blockquote > ul,
 blockquote > ol {
   list-style-position: inside;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-bottom: var(--spacing-8);
-  font-size: var(--fontSize-0);
 }
 
 table th,
@@ -378,7 +379,7 @@ a:focus {
   max-width: var(--maxWidth-wrapper);
   padding: var(--spacing-10) var(--spacing-5);
   overflow-x: hidden;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .post-list-item {
@@ -426,7 +427,7 @@ a:focus {
   object-fit: cover;
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (width >= 600px) {
   .post-list-item section {
     flex-direction: row;
     align-items: center;
@@ -449,56 +450,69 @@ a:focus {
   margin-top: var(--spacing-10);
   margin-bottom: var(--spacing-10);
 }
+
 .bio .avatar {
   margin-right: var(--spacing-4);
   margin-bottom: var(--spacing-0);
   min-width: 60px;
   border-radius: 100%;
 }
+
 .bio .name {
   font-weight: var(--fontWeight-bold);
   margin-bottom: var(--spacing-0);
 }
+
 .bio .job-title {
   font-size: var(--fontSize-0);
   margin-bottom: var(--spacing-0);
 }
+
 .bio ul {
   font-size: var(--fontSize-0);
   margin: var(--spacing-0);
 }
+
 .bio ul li {
   display: inline;
 }
+
 .bio ul li:not(:last-child)::after {
   content: '•';
   margin: 0 var(--spacing-1);
 }
+
 /* Media queries */
-@media screen and (max-width: 600px) {
+@media screen and (width <= 600px) {
   .bio {
     align-items: center;
     flex-direction: column;
   }
+
   .bio .avatar {
     margin-bottom: var(--spacing-4);
   }
+
   .bio .name {
     text-align: center;
   }
+
   .bio .job-title {
     text-align: center;
   }
+
   .bio ul {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-1);
     justify-content: center;
   }
+
   .bio ul li {
     display: inline-flex;
     margin: 0;
   }
+
   .bio ul li:not(:last-child)::after {
     content: '';
     margin: 0 var(--spacing-1);
@@ -512,6 +526,7 @@ a:focus {
 .header {
   margin-bottom: var(--spacing-8);
 }
+
 .header-title {
   font-weight: var(--fontWeight-bold);
   font-family: var(--font-heading);
@@ -519,9 +534,8 @@ a:focus {
   display: block;
   margin-bottom: var(--spacing-4);
   color: var(--color-heading-black);
-  word-wrap: break-word;
-  hyphens: auto;
   overflow-wrap: break-word;
+  hyphens: auto;
 }
 
 .menu {
@@ -546,6 +560,7 @@ a:focus {
   margin: 0 var(--spacing-2);
   color: var(--color-text-light);
 }
+
 .blog-post header {
   margin-bottom: var(--spacing-4);
 }
@@ -583,10 +598,6 @@ a:focus {
 .math.math-display .katex-display {
   padding: 1em;
   margin: 0.5em 0;
-  overflow: auto;
-}
-
-blockquote {
   overflow: auto;
 }
 
@@ -733,11 +744,12 @@ blockquote {
 
 /* Media queries */
 
-@media (max-width: 42rem) {
+@media (width <= 42rem) {
   blockquote {
     padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-4);
     margin-left: var(--spacing-0);
   }
+
   ul,
   ol {
     list-style-position: inside;
@@ -749,7 +761,7 @@ blockquote {
 }
 
 /* Extra small devices */
-@media (max-width: 320px) {
+@media (width <= 320px) {
   .global-wrapper {
     padding: var(--spacing-6) var(--spacing-3);
   }
@@ -770,6 +782,7 @@ blockquote {
     font-size: var(--fontSize-1);
   }
 }
+
 /* Breadcrumbs */
 
 .breadcrumbs {
@@ -813,7 +826,7 @@ blockquote {
   transition:
     background-color 0.2s ease,
     color 0.2s ease;
-  word-break: break-word;
+  overflow-wrap: break-word;
   hyphens: auto;
   max-width: 100%;
   overflow: hidden;
@@ -854,13 +867,13 @@ blockquote {
 }
 
 /* High contrast mode support */
-@media (prefers-contrast: high) {
+@media (prefers-contrast: more) {
   .breadcrumbs a {
     text-decoration: underline;
   }
 
   .breadcrumbs li.active span {
-    outline: 1px solid currentColor;
+    outline: 1px solid currentcolor;
   }
 }
 
@@ -870,6 +883,7 @@ blockquote {
   display: flex;
   justify-content: center;
   margin: var(--spacing-6) 0;
+
   /* Safety net: keep a wide diagram from pushing horizontal scroll onto the
      whole page (notably on phones) — it scrolls within its own box instead. */
   max-width: 100%;
@@ -879,6 +893,7 @@ blockquote {
 .mermaid-diagram svg {
   max-width: 100%;
   height: auto;
+
   /* Flex children default to min-width: auto, which would let the SVG keep its
      intrinsic width and overrun max-width: 100% on narrow viewports. */
   min-width: 0;
@@ -957,20 +972,20 @@ blockquote {
   a[href^='http']::after {
     content: ' (' attr(href) ')';
     font-size: var(--fontSize-0);
-    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   pre,
   blockquote,
   table,
   img {
-    page-break-inside: avoid;
+    break-inside: avoid;
   }
 
   h2,
   h3,
   h4 {
-    page-break-after: avoid;
+    break-after: avoid;
   }
 }
 
@@ -996,6 +1011,7 @@ blockquote {
   html code[class*='language-'],
   html pre[class*='language-'] {
     color: #e6e6e6;
+
     /* The light theme paints a white text-shadow that smears on dark. */
     text-shadow: none;
   }
@@ -1041,6 +1057,7 @@ blockquote {
   html .language-css .token.string,
   html .style .token.string {
     color: #56b6c2;
+
     /* Drop the semi-opaque white background the light theme adds. */
     background: none;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+// Shared types reused across pages and components, so the same shape is not
+// re-declared in each file.
+
+// Per-page SEO metadata. `keywords` feed JSON-LD; title/description also drive
+// the <Seo> meta tags via the layout.
+export interface PageMetadata {
+  title: string;
+  description: string;
+  keywords?: string[];
+}
+
+// A labelled link, used for breadcrumb ancestors and navigation entries.
+export interface NavLink {
+  name: string;
+  url: string;
+}

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+# Security contact for dawidrylko.com (RFC 9116).
+Contact: mailto:hello@dawid.dev
+Expires: 2027-06-19T00:00:00.000Z
+Preferred-Languages: en, pl
+Canonical: https://dawidrylko.com/.well-known/security.txt

--- a/static/humans.txt
+++ b/static/humans.txt
@@ -1,0 +1,13 @@
+/* TEAM */
+Software Engineer: Dawid Ryłko
+Contact: hello [at] dawid.dev
+GitHub: @dawidrylko
+LinkedIn: in/dawidrylko
+Location: Poland
+
+/* SITE */
+Last update: 2026
+Language: English (chrome), Polish (blog)
+Standards: HTML5, CSS3, JSON-LD
+Components: Astro, React, TypeScript, MDX
+Hosting: GitHub Pages

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,27 @@
+# Dawid Ryłko
+
+> Personal website and blog of Dawid Ryłko, a Software Engineer specialising in
+> scalable, secure, and resilient systems. The blog (in Polish) covers software
+> engineering, system architecture, algorithms, and emerging technologies.
+
+This site is built with Astro and hosted on GitHub Pages. Content is welcome to
+be read, cited, and summarised by AI/LLM crawlers.
+
+## Core pages
+
+- [Home](https://dawidrylko.com/): introduction and entry points.
+- [About](https://dawidrylko.com/bio/): professional background, experience, education, and philosophy.
+- [Blog](https://dawidrylko.com/blog/): all articles (in Polish), with search and tag filtering.
+- [Contact](https://dawidrylko.com/contact/): how to get in touch.
+- [Setup](https://dawidrylko.com/setup/): hardware and workstation overview.
+
+## Feeds & metadata
+
+- [RSS feed](https://dawidrylko.com/rss.xml): full-text feed of all blog posts.
+- [Sitemap](https://dawidrylko.com/sitemap-index.xml): canonical list of all URLs.
+
+## Contact
+
+- Email: hello@dawid.dev
+- GitHub: https://github.com/dawidrylko
+- LinkedIn: https://www.linkedin.com/in/dawidrylko

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,36 @@
 User-agent: *
 Allow: /
 
+# AI / LLM crawlers are explicitly welcome (same open posture as above; listed
+# so the intent is unambiguous to operators that look for a named user-agent).
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 Sitemap: https://dawidrylko.com/sitemap-index.xml

--- a/test/mocks/astro-content.ts
+++ b/test/mocks/astro-content.ts
@@ -1,0 +1,17 @@
+// Test stub for the `astro:content` virtual module. `getBlogPosts` (src/lib/blog)
+// reads its collection through `getCollection`; tests seed the returned entries
+// via `__setEntries` before exercising the helper.
+export interface MockPost {
+  id: string;
+  data: { date: Date; [key: string]: unknown };
+}
+
+let entries: MockPost[] = [];
+
+export function __setEntries(next: MockPost[]): void {
+  entries = next;
+}
+
+export async function getCollection(): Promise<MockPost[]> {
+  return entries;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Unit tests cover the framework-agnostic logic in src/lib. `astro:content` is a
+// virtual module that only exists during an Astro build, so it is aliased to a
+// lightweight stub for the few helpers that consume it (see test/mocks).
+export default defineConfig({
+  resolve: {
+    alias: {
+      'astro:content': fileURLToPath(new URL('./test/mocks/astro-content.ts', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
+    },
+  },
+});


### PR DESCRIPTION
Remove duplication across pages and components:

- add formatPolishDate/toISODate (src/lib/date.ts) and use them in the
  blog list, post page and search index instead of repeating the
  toLocaleDateString/toISOString calls
- add createPageSchema factory (src/lib/page-metadata.ts) for the
  WebPage/CollectionPage JSON-LD envelope, replacing the hand-rolled
  objects on the home, bio, contact, 404, setup, files and metadata pages
- add ExternalLink.astro for the target/rel pattern and use it in the
  bio, contact and setup pages and the Bio card
- add Figure.astro for the figure/Picture/figcaption pattern (bio, setup,
  404) with a .figure CSS class replacing the inline margin style
- add shared PageMetadata and NavLink types (src/types.ts)

No rendered output changes: JSON-LD types and external-link rel values
verified identical in the build, and all build-output contracts pass.