### PR TITLE
fix: correct footer, list, and diagram spacing on content pages

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+// Layout regression guards for the footer/list/diagram spacing fixes. These all
+// assert computed geometry on the built site so a future CSS change that drops
+// the spacing (or the marker padding) fails loudly.
+
+test('footer is separated from the divider above it', async ({ page }) => {
+  await page.goto('/');
+  const marginTop = await page.locator('.footer').evaluate(el => Number.parseFloat(getComputedStyle(el).marginTop));
+  expect(marginTop).toBeGreaterThan(0);
+});
+
+test('blog post separates its tag list from the prev/next navigation', async ({ page }) => {
+  await page.goto('/blog/');
+  const href = await page.locator('#blog-posts .post-list-item h2 a').first().getAttribute('href');
+  expect(href).toBeTruthy();
+  await page.goto(href as string);
+
+  const tags = page.locator('article.blog-post .tags');
+  const nav = page.locator('.blog-post-nav');
+  await expect(tags).toBeVisible();
+  await expect(nav).toBeVisible();
+
+  const tagsBox = await tags.boundingBox();
+  const navBox = await nav.boundingBox();
+  expect(tagsBox).not.toBeNull();
+  expect(navBox).not.toBeNull();
+
+  const gap = (navBox?.y ?? 0) - ((tagsBox?.y ?? 0) + (tagsBox?.height ?? 0));
+  expect(gap).toBeGreaterThan(8);
+});
+
+// The global ul/ol reset strips padding and uses outside markers, which the
+// wrapper's overflow-x: hidden would clip. Content sections must re-add the
+// gutter so bullets stay on screen (regression: bio/contact lists ran off the
+// left edge while blog posts were fine).
+for (const route of ['/bio/', '/contact/']) {
+  test(`${route} content list keeps room for its bullet markers`, async ({ page }) => {
+    await page.goto(route);
+    const list = page.locator('main section ul').first();
+    await expect(list).toBeVisible();
+    const paddingLeft = await list.evaluate(el => Number.parseFloat(getComputedStyle(el).paddingLeft));
+    expect(paddingLeft).toBeGreaterThan(0);
+  });
+}
+
+test('setup page server-renders a sized skeleton so the diagram does not jump', async ({ request }) => {
+  const response = await request.get('/setup/');
+  expect(response.ok()).toBeTruthy();
+  const html = await response.text();
+  // The Mermaid island is client:load, so its loading placeholder is part of the
+  // server-rendered HTML and reserves height before hydration.
+  expect(html).toContain('mermaid-diagram-skeleton');
+});
+
+test('setup page eventually renders the mermaid diagram', async ({ page }) => {
+  await page.goto('/setup/');
+  await expect(page.locator('#diagram .mermaid-diagram svg')).toBeVisible();
+});

--- a/helpers/ci/check-astro-build-output.mjs
+++ b/helpers/ci/check-astro-build-output.mjs
@@ -10,7 +10,7 @@
  *   - the /setup/ Mermaid diagram hydrates (client:load island)
  *   - the memoization post's interactive demo hydrates (client:visible island)
  *   - blog-list thumbnails render at a bounded (600px) size, not full-res
- *   - post-body list markers stay outside (not dropped onto their own line)
+ *   - content list markers stay outside (not dropped onto their own line / clipped)
  *   - breadcrumbs truncate on one line (no horizontal-scroll fallback)
  *   - the /files/ page lists presentations (static/files is read from disk)
  *   - the /files/ cmd/ctrl+shift+. hidden-variant toggle ships and is wired up
@@ -79,8 +79,15 @@ async function checkCodeDarkTheme(css) {
 }
 
 async function checkListMarkers(css) {
-  if (!/\.blog-post section ul[^{]*\{[^}]*list-style-position:\s*outside/.test(css)) {
-    fail('post-body lists missing list-style-position: outside (markers regressed inside)');
+  // Content lists (blog post bodies plus the bio/contact sections) re-add the
+  // gutter the global ul/ol reset strips and keep markers outside, so the
+  // wrapper's overflow-x: hidden does not clip them onto their own line / off
+  // the left edge.
+  if (!/main section ul[^{]*\{[^}]*list-style-position:\s*outside/.test(css)) {
+    fail('content lists missing list-style-position: outside (markers regressed inside)');
+  }
+  if (!/main section ul[^{]*\{[^}]*padding-left/.test(css)) {
+    fail('content lists missing padding-left gutter (outside markers would be clipped)');
   }
 }
 

--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -76,7 +76,11 @@ const MermaidInner: FC<Required<MermaidProps>> = ({ chart, ariaLabel }) => {
   }
 
   if (!svg) {
-    return null;
+    // Server-rendered too (client:load), so the reserved height is present on
+    // first paint and the content below does not jump when the SVG arrives.
+    return (
+      <div className="mermaid-diagram-skeleton" role="status" aria-label={`${ariaLabel} – loading`} aria-busy="true" />
+    );
   }
 
   return (

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -265,11 +265,13 @@ li > ul {
 }
 
 /* Prose lists need room for outside markers; the global ul/ol reset removes
-   padding for the layout lists (menu, bio, posts), so re-add it for post body
-   content only, where markers would otherwise be clipped by the wrapper's
-   overflow-x: hidden. */
-.blog-post section ul,
-.blog-post section ol {
+   padding for the layout lists (menu, bio, posts), so re-add it for in-page
+   content lists — blog post bodies plus the bio/contact sections — where the
+   markers would otherwise be clipped by the wrapper's overflow-x: hidden. The
+   layout lists (.tags, .posts, .pagination, menu, bio) live outside any
+   `main section`, so they keep their reset. */
+main section ul,
+main section ol {
   padding-left: var(--spacing-6);
 
   /* Keep markers in the gutter beside the text. Without this, the mobile
@@ -597,6 +599,12 @@ a:focus {
 }
 
 /* Previous/next post navigation: spread the two links across the row. */
+.blog-post-nav {
+  /* Separate the nav from the tag list above it (the tags carry only a top
+     margin, so without this they sit flush against the prev/next links). */
+  margin-top: var(--spacing-8);
+}
+
 .blog-post-nav ul {
   display: flex;
   flex-wrap: wrap;
@@ -891,6 +899,10 @@ a:focus {
      whole page (notably on phones) — it scrolls within its own box instead. */
   max-width: 100%;
   overflow-x: auto;
+
+  /* Fade the finished diagram in so the swap from skeleton to SVG is not a hard
+     pop. Runs once, when the SVG first mounts. */
+  animation: mermaid-diagram-fade-in 0.3s ease-in;
 }
 
 .mermaid-diagram svg {
@@ -906,6 +918,47 @@ a:focus {
   overflow-x: auto;
 }
 
+/* Loading placeholder shown (and server-rendered) while the diagram is being
+   built on the client. Reserving height up front keeps the content below from
+   jumping when the SVG replaces it, and the shimmer signals progress. */
+.mermaid-diagram-skeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 20rem;
+  margin: var(--spacing-6) 0;
+  border-radius: var(--spacing-2);
+  background-image: linear-gradient(
+    100deg,
+    var(--color-accent) 25%,
+    var(--color-background) 50%,
+    var(--color-accent) 75%
+  );
+  background-size: 200% 100%;
+  animation: mermaid-skeleton-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes mermaid-skeleton-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@keyframes mermaid-diagram-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mermaid-diagram svg * {
     animation: none !important;
@@ -919,6 +972,10 @@ a:focus {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+
+  /* Match the breathing room the bio has around its dividers so the footer is
+     not flush against the rule above it. */
+  margin-top: var(--spacing-8);
 }
 
 .footer-metadata a {


### PR DESCRIPTION
- Add a top margin to the footer so it is not flush against the divider
  above it, matching the breathing room the bio has around its rules.
- Separate the blog post tag list from the prev/next navigation, which
  previously sat flush against the tags.
- Re-add the marker gutter to bio/contact content lists (generalise the
  blog-post rule to `main section ul/ol`) so outside bullets are no longer
  clipped by the wrapper's overflow-x: hidden.
- Render a server-rendered, height-reserving skeleton while the Mermaid
  diagram loads so the content below no longer jumps when the SVG mounts,
  and fade the finished diagram in.
- Add e2e regression guards for all four cases.