### PR TITLE
fix(seo): resolve Ahrefs metadata errors and add regression guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,12 @@ jobs:
       - name: Verify SEO / structured-data contract
         run: node helpers/ci/check-seo-meta.mjs
 
+      - name: Verify SEO title/description lengths
+        run: node helpers/ci/check-seo-lengths.mjs
+
+      - name: Verify image weight budget
+        run: node helpers/ci/check-image-budget.mjs
+
   # Internal link integrity across the built site (catches broken links and
   # broken redirects). External URLs are skipped to keep the gate deterministic.
   links:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,16 @@ Potrzebne przy modyfikacji `[...slug].astro`, `content.config.ts`, RSS (`rss.xml
 - **Prettier:** single quotes, średniki, 2 spacje, `printWidth: 120`, `arrowParens: avoid`, plugin `prettier-plugin-astro`.
 - **Komentarze:** tylko po angielsku i tylko te realnie wartościowe — wyjaśniaj „dlaczego”, a nie to, co kod już mówi sam.
 
+## SEO i metadane (limity Ahrefs)
+
+Audyt Ahrefs pilnuje długości i poprawności metadanych. Reguły poniżej dotyczą stron, które kontrolujemy (kod w repo) — pilnują ich testy jednostkowe (`src/lib/seo.test.ts`) i checki na zbudowanym `dist/`.
+
+- **Limity długości** (`src/lib/seo.ts`): `<title>` ≤ **60** znaków, `<meta name="description">` ≤ **160**. Zmieniając tytuł/opis strony statycznej (`src/pages/*`) lub fallback w `site-metadata.ts`, mieść się w limitach. Sprawdza je `helpers/ci/check-seo-lengths.mjs` (twardo dla stron własnych: `/`, `/blog/*`, `/bio/`, `/contact/`, `/setup/`, `/metadata/`, `/files/`; posty z `content/pl` tylko ostrzega — ich tytuł/opis pochodzą z frontmatteru autora).
+- **Tytuł strony głównej** budowany jest z `SITE_METADATA.title` + `titleTagline` (krótki, ≤60 z marką). `author.jobTitle` (pełny opis roli) jest dłuższy i służy tylko do Bio + JSON-LD — nie używaj go w `<title>`.
+- **Fallback opisu** (`SITE_METADATA.description`) musi być ≤160 i **bez** easter-egga „68 97 119…” (ten należy do nagłówka, nie do snippetu w SERP).
+- **Canonical:** strony `noIndex` (np. 404) **nie** emitują `<link rel="canonical">` (wskazywałby na URL non-200). Pilnują tego `helpers/ci/check-seo-meta.mjs` i smoke test.
+- **Budżet obrazów:** każdy obraz w `dist/` ≤ **1 MB** (`helpers/ci/check-image-budget.mjs`). Istniejące, cięższe obrazy postów są tymczasowo na liście wyjątków (`image-budget-baseline.json`); **nowe** ponadwymiarowe obrazy blokują CI — optymalizuj/zmniejszaj źródło przed dodaniem. Po świadomej optymalizacji odśwież baseline: `node helpers/ci/check-image-budget.mjs --update-baseline`.
+
 ## Czego nie zmieniać
 
 - **Nie zmieniaj `lang="en"`** w `PageLayout.astro` / `Seo.astro` mimo polskich treści — to celowa decyzja.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -36,6 +36,10 @@ test('unknown route serves the 404 page', async ({ page }) => {
   const response = await page.goto('/no-such-page-please/');
   expect(response?.status()).toBe(404);
   await expect(page.locator('h1')).toContainText('Page Not Found');
+
+  // The noindex 404 must not advertise a canonical: it would point at a non-200
+  // URL, which SEO audits flag.
+  await expect(page.locator('link[rel="canonical"]')).toHaveCount(0);
 });
 
 test('dark mode applies the dark background token', async ({ page }) => {

--- a/helpers/ci/README.md
+++ b/helpers/ci/README.md
@@ -25,6 +25,32 @@ runs in the `build-contract` job against the shared build artifact, so it never
 triggers its own build. Rendered-page audits (Lighthouse) and link integrity
 (linkinator) live in separate jobs to keep responsibilities from overlapping.
 
+## `check-seo-lengths.mjs`
+
+Enforces the SEO length limits (mirrored in `src/lib/seo.ts`) on the rendered
+pages: `<title>` ≤ 60 chars and `<meta name="description">` ≤ 160. App-owned
+routes (`/`, `/blog/*`, `/bio/`, `/contact/`, `/setup/`, `/metadata/`, `/files/`)
+fail the build; blog posts (author content from MDX frontmatter) are reported as
+warnings only. Runs in the `build-contract` job.
+
+```bash
+pnpm build
+node helpers/ci/check-seo-lengths.mjs
+```
+
+## `check-image-budget.mjs`
+
+Fails when an emitted image exceeds the 1 MB per-file budget. Existing oversized
+post images are grandfathered by source-name stem in `image-budget-baseline.json`,
+so only **new** oversized images break the build. Runs in the `build-contract`
+job. After intentionally optimising images, refresh the baseline:
+
+```bash
+pnpm build
+node helpers/ci/check-image-budget.mjs                  # check
+node helpers/ci/check-image-budget.mjs --update-baseline # regenerate baseline
+```
+
 ## `check-no-ai-attribution.mjs`
 
 Enforces the no-AI-attribution rule from `CLAUDE.md`: fails if a commit message

--- a/helpers/ci/check-image-budget.mjs
+++ b/helpers/ci/check-image-budget.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Image weight budget for the Astro build (dist/).
+ *
+ * Oversized images are the heaviest Core Web Vitals / SEO regression a content
+ * site ships (Ahrefs "image file size too big"). This walks every emitted image
+ * and fails when one exceeds the per-file budget.
+ *
+ * Existing oversized images are author content (post illustrations, processed
+ * by astro:assets) and cannot be re-encoded from here, so they are grandfathered
+ * via image-budget-baseline.json — a list of file-name stems (the part before
+ * the first dot, stable across content-hash changes). A NEW image over budget
+ * whose stem is not baselined fails the build, which is the regression guard:
+ * future images must be optimised before they are added.
+ *
+ * Regenerate the baseline after intentionally optimising images:
+ *   node helpers/ci/check-image-budget.mjs --update-baseline
+ *
+ * Zero dependencies; runs against the built output, it does NOT rebuild.
+ */
+
+import { readFile, writeFile, readdir, stat, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative, basename } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2).filter(a => a !== '--update-baseline');
+const UPDATE_BASELINE = process.argv.includes('--update-baseline');
+const DIST_DIR = args[0] ? resolve(process.cwd(), args[0]) : resolve(__dirname, '../../dist');
+const BASELINE_FILE = resolve(__dirname, 'image-budget-baseline.json');
+
+// 1 MB. Optimised web images (AVIF/WebP, sensibly sized JPEG) land well under
+// this; anything larger is an unoptimised original.
+const MAX_BYTES = 1024 * 1024;
+const IMAGE_EXT = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif']);
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// astro:assets emits `<source-name>.<8-char-hash>[_<variant>].<ext>`; the hash
+// changes with content but the source name does not. Source names can contain
+// dots (e.g. "2.Raspberry-Pi-3"), so strip the trailing hash+variant+ext rather
+// than splitting on the first dot.
+const HASH_SUFFIX = /\.[A-Za-z0-9_-]{8}(?:_[A-Za-z0-9]+)?\.[a-z0-9]+$/;
+
+/** The stable source stem of an emitted asset (hash and extension removed). */
+function stemOf(file) {
+  const name = basename(file);
+  const match = name.match(HASH_SUFFIX);
+  if (match) return name.slice(0, match.index);
+  // No Astro hash (e.g. a verbatim static/ asset): drop just the extension.
+  const dot = name.lastIndexOf('.');
+  return dot === -1 ? name : name.slice(0, dot);
+}
+
+async function collectImages(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return collectImages(full);
+      const dot = entry.name.lastIndexOf('.');
+      const ext = dot === -1 ? '' : entry.name.slice(dot).toLowerCase();
+      return IMAGE_EXT.has(ext) ? [full] : [];
+    }),
+  );
+  return files.flat();
+}
+
+async function loadBaseline() {
+  if (!(await exists(BASELINE_FILE))) return new Set();
+  return new Set(JSON.parse(await readFile(BASELINE_FILE, 'utf8')));
+}
+
+async function main() {
+  if (!(await exists(DIST_DIR))) {
+    console.error(`Build output not found at ${DIST_DIR}. Run "pnpm build" first.`);
+    process.exit(1);
+  }
+
+  const images = await collectImages(DIST_DIR);
+  const oversized = [];
+  for (const image of images) {
+    const { size } = await stat(image);
+    if (size > MAX_BYTES) oversized.push({ rel: relative(DIST_DIR, image), stem: stemOf(image), size });
+  }
+
+  if (UPDATE_BASELINE) {
+    const stems = [...new Set(oversized.map(o => o.stem))].sort();
+    await writeFile(BASELINE_FILE, `${JSON.stringify(stems, null, 2)}\n`);
+    console.log(`Wrote ${stems.length} grandfathered stem(s) to ${relative(process.cwd(), BASELINE_FILE)}.`);
+    return;
+  }
+
+  const baseline = await loadBaseline();
+  const mb = bytes => `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  const offenders = oversized.filter(o => !baseline.has(o.stem));
+  const grandfathered = oversized.filter(o => baseline.has(o.stem));
+
+  console.log(`Image weight budget (dist/): ${mb(MAX_BYTES)} per file\n`);
+  for (const g of grandfathered.sort((a, b) => b.size - a.size)) {
+    console.warn(`  ⚠ grandfathered: ${g.rel} (${mb(g.size)})`);
+  }
+
+  if (offenders.length > 0) {
+    for (const o of offenders.sort((a, b) => b.size - a.size)) {
+      console.error(`  ✗ ${o.rel} is ${mb(o.size)} (max ${mb(MAX_BYTES)})`);
+    }
+    console.error(
+      `\nImage budget failed: ${offenders.length} new oversized image(s). ` +
+        `Optimise/resize the source, or run with --update-baseline if this is intentional.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `  ✓ ${images.length} image(s) within budget` +
+      (grandfathered.length ? ` (${grandfathered.length} grandfathered above).` : '.'),
+  );
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/helpers/ci/check-seo-lengths.mjs
+++ b/helpers/ci/check-seo-lengths.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * SEO length contract for the Astro build (dist/).
+ *
+ * Search engines truncate the <title> and <meta name="description"> in results,
+ * and SEO audits (Ahrefs "title too long" / "meta description too long") flag
+ * anything longer. This walks every rendered page and enforces the limits on
+ * the routes the app owns (the static pages, whose copy lives in this repo):
+ *
+ *   - <title>            ≤ 60 chars
+ *   - <meta description> ≤ 160 chars
+ *
+ * Blog post pages are author content (their title/description come from MDX
+ * frontmatter); they are reported as warnings but never fail the build, so the
+ * gate stays green while still surfacing posts worth tightening.
+ *
+ * Limits mirror TITLE_MAX_LENGTH / DESCRIPTION_MAX_LENGTH in src/lib/seo.ts.
+ * Redirect stubs (meta-refresh pages) are skipped. Zero dependencies; runs
+ * against the built output, it does NOT rebuild.
+ */
+
+import { readFile, readdir, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative, sep } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : resolve(__dirname, '../../dist');
+
+const TITLE_MAX_LENGTH = 60;
+const DESCRIPTION_MAX_LENGTH = 160;
+
+// First path segment of every app-owned route. The homepage is '' (index.html);
+// blog covers the listing and its pagination (blog/, blog/2/, …). Everything
+// else (top-level post slugs, 404) is author content and only warned about.
+const OWNED_SEGMENTS = new Set(['', 'bio', 'contact', 'setup', 'metadata', 'files', 'blog']);
+
+const problems = [];
+const warnings = [];
+const fail = msg => problems.push(msg);
+const warn = msg => warnings.push(msg);
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Recursively collect every .html file under dir. */
+async function collectHtml(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return collectHtml(full);
+      return entry.name.endsWith('.html') ? [full] : [];
+    }),
+  );
+  return files.flat();
+}
+
+/** Decode the handful of HTML entities that appear in titles/descriptions. */
+function decodeEntities(text) {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function isOwnedRoute(rel) {
+  return OWNED_SEGMENTS.has(
+    rel
+      .split(sep)[0]
+      .replace(/\.html$/, '')
+      .replace(/index$/, ''),
+  );
+}
+
+function checkPage(rel, html) {
+  // Redirect stubs have no real <head> chrome — skip them.
+  if (/http-equiv="refresh"/i.test(html)) return;
+
+  const owned = isOwnedRoute(rel);
+  const report = owned ? fail : warn;
+
+  const titleMatch = html.match(/<title>([\s\S]*?)<\/title>/);
+  if (titleMatch) {
+    const title = decodeEntities(titleMatch[1].trim());
+    if (title.length > TITLE_MAX_LENGTH) {
+      report(`${rel}: <title> is ${title.length} chars (max ${TITLE_MAX_LENGTH}) — "${title}"`);
+    }
+  }
+
+  const descMatch = html.match(/<meta[^>]*name="description"[^>]*content="([^"]*)"/);
+  if (descMatch) {
+    const description = decodeEntities(descMatch[1].trim());
+    if (description.length > DESCRIPTION_MAX_LENGTH) {
+      report(`${rel}: meta description is ${description.length} chars (max ${DESCRIPTION_MAX_LENGTH})`);
+    }
+  }
+}
+
+async function main() {
+  if (!(await exists(DIST_DIR))) {
+    console.error(`Build output not found at ${DIST_DIR}. Run "pnpm build" first.`);
+    process.exit(1);
+  }
+
+  const pages = await collectHtml(DIST_DIR);
+  if (pages.length === 0) fail('no HTML pages found in dist');
+
+  for (const page of pages) {
+    const rel = relative(DIST_DIR, page);
+    checkPage(rel, await readFile(page, 'utf8'));
+  }
+
+  console.log('SEO length contract (dist/)\n');
+  for (const warning of warnings) console.warn(`  ⚠ ${warning}`);
+
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(`  ✗ ${problem}`);
+    console.error(`\nSEO length contract failed: ${problems.length} problem(s) on app-owned pages.`);
+    process.exit(1);
+  }
+  console.log(
+    `  ✓ ${pages.length} page(s): app-owned titles ≤ ${TITLE_MAX_LENGTH} and descriptions ≤ ${DESCRIPTION_MAX_LENGTH} chars` +
+      (warnings.length ? ` (${warnings.length} author-content warning(s) above).` : '.'),
+  );
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/helpers/ci/check-seo-lengths.mjs
+++ b/helpers/ci/check-seo-lengths.mjs
@@ -61,14 +61,12 @@ async function collectHtml(dir) {
   return files.flat();
 }
 
-/** Decode the handful of HTML entities that appear in titles/descriptions. */
+/** The handful of HTML entities that appear in titles/descriptions. */
+const HTML_ENTITIES = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'" };
+
+/** Decode those entities in a single pass so "&amp;lt;" is not double-unescaped. */
 function decodeEntities(text) {
-  return text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
+  return text.replace(/&(?:amp|lt|gt|quot|#39);/g, entity => HTML_ENTITIES[entity]);
 }
 
 function isOwnedRoute(rel) {

--- a/helpers/ci/check-seo-meta.mjs
+++ b/helpers/ci/check-seo-meta.mjs
@@ -80,10 +80,18 @@ function checkPage(page, html) {
   if (!description || !description[1].trim()) fail(`${page}: missing or empty meta description`);
 
   const canonical = html.match(/<link[^>]*rel="canonical"[^>]*href="([^"]*)"/);
-  // Compare the parsed origin (not a substring) so a look-alike host such as
-  // https://dawidrylko.com.evil.com/ cannot pass the check.
-  const canonicalOrigin = canonical && URL.canParse(canonical[1]) ? new URL(canonical[1]).origin : null;
-  if (canonicalOrigin !== ORIGIN) fail(`${page}: missing or non-canonical canonical link`);
+  // noindex pages (e.g. the 404) must not carry a canonical at all: a self
+  // canonical would point at a non-200 URL, which SEO audits flag. Indexable
+  // pages must carry one pointing at the production origin.
+  const isNoindex = /<meta[^>]*name="robots"[^>]*content="[^"]*noindex/i.test(html);
+  if (isNoindex) {
+    if (canonical) fail(`${page}: noindex page must not emit a canonical link`);
+  } else {
+    // Compare the parsed origin (not a substring) so a look-alike host such as
+    // https://dawidrylko.com.evil.com/ cannot pass the check.
+    const canonicalOrigin = canonical && URL.canParse(canonical[1]) ? new URL(canonical[1]).origin : null;
+    if (canonicalOrigin !== ORIGIN) fail(`${page}: missing or non-canonical canonical link`);
+  }
 
   for (const [i, block] of ldJsonBlocks(html).entries()) {
     try {

--- a/helpers/ci/image-budget-baseline.json
+++ b/helpers/ci/image-budget-baseline.json
@@ -3,7 +3,6 @@
   "3.Czujniki-Xiaomi-Flower-Care",
   "6.Apple-HomePod-Mini",
   "7.Zestaw-z-Raspberry-Pi-5-8GB",
-  "DALL·E - A modern blog page featuring an article about AI in Chrome_ viewed from a computer screen perspective",
   "Dumbledore_przy_komputerze",
   "McGonagall_podczas_transmutacji",
   "books",
@@ -11,7 +10,6 @@
   "dominik-scythe-Sot0f3hQQ4Y-unsplash",
   "domino",
   "elevator",
-  "hardware-setup",
   "kwiaty-czy-ziola",
   "pin-on-the-map",
   "rock-n-roll-monkey-R4WCbazrD1g-unsplash"

--- a/helpers/ci/image-budget-baseline.json
+++ b/helpers/ci/image-budget-baseline.json
@@ -1,0 +1,18 @@
+[
+  "2.Raspberry-Pi-3",
+  "3.Czujniki-Xiaomi-Flower-Care",
+  "6.Apple-HomePod-Mini",
+  "7.Zestaw-z-Raspberry-Pi-5-8GB",
+  "DALL·E - A modern blog page featuring an article about AI in Chrome_ viewed from a computer screen perspective",
+  "Dumbledore_przy_komputerze",
+  "McGonagall_podczas_transmutacji",
+  "books",
+  "boxes",
+  "dominik-scythe-Sot0f3hQQ4Y-unsplash",
+  "domino",
+  "elevator",
+  "hardware-setup",
+  "kwiaty-czy-ziola",
+  "pin-on-the-map",
+  "rock-n-roll-monkey-R4WCbazrD1g-unsplash"
+]

--- a/src/components/Figure.astro
+++ b/src/components/Figure.astro
@@ -4,7 +4,8 @@ import type { ImageMetadata } from 'astro';
 
 // Responsive image with an optional caption — the repeated
 // <figure><Picture/><figcaption/></figure> pattern from the bio, setup and 404
-// pages. Emits AVIF/WebP sources at full container width.
+// pages. Emits AVIF/WebP sources with a WebP fallback (universally supported,
+// far lighter than the original PNG/JPEG).
 interface Props {
   src: ImageMetadata;
   alt: string;
@@ -15,6 +16,6 @@ const { src, alt, caption } = Astro.props;
 ---
 
 <figure class="figure">
-  <Picture src={src} formats={['avif', 'webp']} layout="full-width" alt={alt} />
+  <Picture src={src} formats={['avif', 'webp']} fallbackFormat="webp" layout="full-width" alt={alt} />
   {caption && <figcaption>{caption}</figcaption>}
 </figure>

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -1,5 +1,6 @@
 ---
 import { SITE_METADATA } from '../data/site-metadata';
+import { resolveMetaTitle, resolveMetaDescription } from '../lib/seo';
 
 // Port of the Gatsby <Seo> component (src/components/seo.tsx): title, description,
 // canonical/OG url, Open Graph and Twitter Card meta. The <html lang> attribute
@@ -43,11 +44,10 @@ const OG_LOCALES: Record<string, string> = { en: 'en_US', pl: 'pl_PL' };
 
 const metaLang = lang ?? SITE_METADATA.lang;
 const siteTitle = SITE_METADATA.title;
-const siteDescription = SITE_METADATA.description.en;
 const author = SITE_METADATA.author;
 
-const metaDescription = description || siteDescription;
-const metaTitle = title ? `${title} | ${siteTitle}` : `${siteTitle} | ${author.jobTitle}`;
+const metaDescription = resolveMetaDescription(description);
+const metaTitle = resolveMetaTitle(title);
 const metaImageAlt = imageAlt ?? metaTitle;
 
 const twitterUrl = SITE_METADATA.social.find(({ name }) => name === 'Twitter')?.url ?? '';

--- a/src/data/site-metadata.ts
+++ b/src/data/site-metadata.ts
@@ -4,9 +4,15 @@ export const SITE_METADATA = {
   lang: 'en',
   url: 'https://dawidrylko.com',
   title: 'Dawid Ryłko',
+  // Short tagline used only for the homepage <title> (siteTitle | tagline), kept
+  // under the 60-char SEO limit. The full role copy lives in author.jobTitle.
+  titleTagline: 'Software Engineer | Scalable, Secure Systems',
+  // Fallback meta description for pages without their own. Kept ≤160 chars and
+  // free of the decimal-ASCII easter egg (that belongs in the header, not in
+  // search snippets).
   description: {
-    en: 'Welcome to Dawid Ryłko’s personal website and blog. Find articles, insights, and updates from the world of technology here. 68 97 119 105 100 32 82 121 108 107 111',
-    pl: 'Witaj na osobistej stronie i blogu Dawida Ryłko. Znajdziesz tutaj artykuły, spostrzeżenia i aktualizacje ze świata technologii. 68 97 119 105 100 32 82 121 108 107 111',
+    en: 'Personal website and blog of Dawid Ryłko, Software Engineer—articles and insights on software architecture, scalable systems, and modern web.',
+    pl: 'Osobista strona i blog Dawida Ryłko, Software Engineera — artykuły o architekturze systemów, skalowalności i nowoczesnym wytwarzaniu oprogramowania.',
   },
   author: {
     name: 'Dawid Ryłko',

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -69,7 +69,11 @@ const { website } = STRUCTURED_DATA;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="canonical" href={canonical} />
+    {
+      /* noindex pages (e.g. 404) must not advertise a canonical: theirs would
+        point at a non-200 URL, which SEO audits flag. */
+    }
+    {!noIndex && <link rel="canonical" href={canonical} />}
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#005b99" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { SITE_METADATA } from '../data/site-metadata';
+import {
+  TITLE_MAX_LENGTH,
+  DESCRIPTION_MAX_LENGTH,
+  resolveMetaTitle,
+  resolveMetaDescription,
+  isWithinTitleLimit,
+  isWithinDescriptionLimit,
+} from './seo';
+
+describe('resolveMetaTitle', () => {
+  it('renders a page title as "Title | Site"', () => {
+    expect(resolveMetaTitle('About')).toBe(`About | ${SITE_METADATA.title}`);
+  });
+
+  it('falls back to the brand title plus the short tagline when no title is given', () => {
+    expect(resolveMetaTitle()).toBe(`${SITE_METADATA.title} | ${SITE_METADATA.titleTagline}`);
+  });
+
+  it('keeps the homepage (tagline) title within the SEO limit', () => {
+    expect(isWithinTitleLimit(resolveMetaTitle())).toBe(true);
+  });
+});
+
+describe('resolveMetaDescription', () => {
+  it('returns the page description when provided', () => {
+    expect(resolveMetaDescription('Custom page description')).toBe('Custom page description');
+  });
+
+  it('falls back to the site description when none is provided', () => {
+    expect(resolveMetaDescription()).toBe(SITE_METADATA.description.en);
+    expect(resolveMetaDescription('')).toBe(SITE_METADATA.description.en);
+  });
+
+  it('keeps the fallback site descriptions within the SEO limit and free of the ASCII easter egg', () => {
+    for (const description of Object.values(SITE_METADATA.description)) {
+      expect(isWithinDescriptionLimit(description)).toBe(true);
+      // The decimal-ASCII header easter egg must not leak into search snippets.
+      expect(description).not.toMatch(/\b68 97 119\b/);
+    }
+  });
+});
+
+describe('length guards', () => {
+  it('flags values at and beyond the boundaries', () => {
+    expect(isWithinTitleLimit('a'.repeat(TITLE_MAX_LENGTH))).toBe(true);
+    expect(isWithinTitleLimit('a'.repeat(TITLE_MAX_LENGTH + 1))).toBe(false);
+    expect(isWithinDescriptionLimit('a'.repeat(DESCRIPTION_MAX_LENGTH))).toBe(true);
+    expect(isWithinDescriptionLimit('a'.repeat(DESCRIPTION_MAX_LENGTH + 1))).toBe(false);
+  });
+});

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,29 @@
+import { SITE_METADATA } from '../data/site-metadata';
+
+// Search engines truncate titles and descriptions in results; values past these
+// limits get cut in SERPs and are flagged by SEO audits (Ahrefs "title too
+// long" / "meta description too long"). Enforced on the pages we control by the
+// unit tests next to this file and by helpers/ci/check-seo-lengths.mjs on the
+// rendered output.
+export const TITLE_MAX_LENGTH = 60;
+export const DESCRIPTION_MAX_LENGTH = 160;
+
+const siteTitle = SITE_METADATA.title;
+const siteDescription = SITE_METADATA.description.en;
+
+/**
+ * The document <title> / og:title text for a page. Pages pass their own short
+ * title (rendered as "Title | Site"); the homepage passes none and falls back
+ * to the brand title plus the short tagline, keeping it under TITLE_MAX_LENGTH.
+ */
+export function resolveMetaTitle(title?: string): string {
+  return title ? `${title} | ${siteTitle}` : `${siteTitle} | ${SITE_METADATA.titleTagline}`;
+}
+
+/** The meta description for a page, falling back to the site description. */
+export function resolveMetaDescription(description?: string): string {
+  return description || siteDescription;
+}
+
+export const isWithinTitleLimit = (value: string): boolean => value.length <= TITLE_MAX_LENGTH;
+export const isWithinDescriptionLimit = (value: string): boolean => value.length <= DESCRIPTION_MAX_LENGTH;

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -102,7 +102,13 @@ const structuredData = {
     </header>
     {
       featuredImg && (
-        <Picture src={featuredImg} formats={['avif', 'webp']} layout="full-width" alt={featuredImgAlt ?? ''} />
+        <Picture
+          src={featuredImg}
+          formats={['avif', 'webp']}
+          fallbackFormat="webp"
+          layout="full-width"
+          alt={featuredImgAlt ?? ''}
+        />
       )
     }
     <section>

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -13,7 +13,7 @@ import type { PageMetadata } from '../types';
 const PAGE_METADATA: PageMetadata = {
   title: 'About',
   description:
-    'Meet Dawid Ryłko—a Software Engineer with 10+ years of experience building scalable, secure, and resilient systems. Learn about his professional journey, technical expertise in full-stack development, AI integration, cybersecurity, educational background, and philosophy behind creating meaningful technology.',
+    'Dawid Ryłko—Software Engineer with 10+ years building scalable, secure systems. Career, full-stack expertise, AI integration, and cybersecurity.',
   keywords: [
     'Dawid Ryłko',
     'Software Engineer',

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
-import { Image, Picture } from 'astro:assets';
+import { Image, Picture, getImage } from 'astro:assets';
 import PageLayout from '../../layouts/PageLayout.astro';
 import JsonLd from '../../components/JsonLd.astro';
 import rssIcon from '../../assets/rss.svg';
@@ -53,6 +53,19 @@ const items = page.data.map(post => {
   return { post, description, descriptionHtml, dateFormatted };
 });
 
+// Optimised WebP URL per post for the JSON-LD image, keyed by post id. Using the
+// raw featuredImg.src would emit the full-size original into the build.
+const featuredImageUrls = new Map(
+  await Promise.all(
+    items
+      .filter(({ post }) => post.data.featuredImg)
+      .map(async ({ post }): Promise<[string, string]> => {
+        const image = await getImage({ src: post.data.featuredImg!, width: 1200, format: 'webp' });
+        return [post.id, image.src];
+      }),
+  ),
+);
+
 // Build a stable href for any page number (page 1 keeps the bare /blog/ URL).
 const pageHref = (n: number) => (n === 1 ? '/blog/' : `/blog/${n}/`);
 
@@ -75,7 +88,7 @@ const structuredData = {
     datePublished: toISODate(post.data.date),
     author: { '@type': 'Person', name: author.name },
     image: post.data.featuredImg
-      ? { '@type': 'ImageObject', url: post.data.featuredImg.src, description: post.data.featuredImgAlt || '' }
+      ? { '@type': 'ImageObject', url: featuredImageUrls.get(post.id), description: post.data.featuredImgAlt || '' }
       : undefined,
     url: `${SITE_METADATA.url}/${post.id}/`,
   })),
@@ -131,6 +144,7 @@ const structuredData = {
                   <Picture
                     src={post.data.featuredImg}
                     formats={['avif', 'webp']}
+                    fallbackFormat="webp"
                     width={600}
                     sizes="(min-width: 37.5rem) 200px, 100vw"
                     alt={post.data.featuredImgAlt || ''}

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -15,7 +15,7 @@ import { formatPolishDate, toISODate } from '../../lib/date';
 const PAGE_METADATA = {
   title: 'Blog 🇵🇱',
   description:
-    'Artykuły i wpisy na blogu Dawida Ryłko o programowaniu, technologiach, architekturze systemów i rozwoju oprogramowania. Praktyczne porady, spostrzeżenia ze świata IT i nowoczesne podejście do tworzenia aplikacji webowych.',
+    'Blog Dawida Ryłko o programowaniu, technologiach, architekturze systemów i wytwarzaniu oprogramowania. Praktyczne porady i spostrzeżenia ze świata IT.',
   keywords: [
     'blog programistyczny',
     'artykuły IT',

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -10,7 +10,7 @@ import type { PageMetadata } from '../types';
 const PAGE_METADATA: PageMetadata = {
   title: 'Contact',
   description:
-    'Get in touch with Dawid Ryłko for software engineering projects, system architecture consulting, and technology collaboration. Available for scalable, secure, and future-proof solutions across the full technology stack—from frontend to backend, cloud infrastructure, AI integration, and cybersecurity.',
+    'Get in touch with Dawid Ryłko for software engineering, system architecture consulting, and technology collaboration across the full stack.',
   keywords: [
     'contact Dawid Ryłko',
     'software engineering services',

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -144,7 +144,7 @@ const rows = sortedEntries
 const PAGE_METADATA: PageMetadata = {
   title: 'Files',
   description:
-    'Browse and download technical presentations, slides, and educational materials by Dawid Ryłko. Access professionally crafted resources covering software development, Node.js, TypeScript, and modern web technologies—available in multiple formats and languages.',
+    'Browse and download technical presentations and slides by Dawid Ryłko on software development, Node.js, TypeScript, and modern web technologies.',
   keywords: [
     'technical presentations',
     'software development slides',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import type { PageMetadata } from '../types';
 const PAGE_METADATA: PageMetadata = {
   title: 'Home',
   description:
-    'Dawid Ryłko - Software Engineer specializing in scalable, secure, and resilient systems. Explore articles on software engineering, system architecture, and emerging technologies. Available for collaboration on meaningful technology projects.',
+    'Dawid Ryłko—Software Engineer building scalable, secure, and resilient systems. Articles on software engineering, architecture, and emerging tech.',
   keywords: [
     'Dawid Ryłko',
     'Software Engineer',
@@ -39,7 +39,7 @@ const structuredData = createPageSchema({
 });
 ---
 
-<PageLayout breadcrumbTitle={PAGE_METADATA.title}>
+<PageLayout breadcrumbTitle={PAGE_METADATA.title} description={PAGE_METADATA.description}>
   <JsonLd data={structuredData} />
   <header>
     <h1>Hi, I'm Dawid Ryłko</h1>

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -32,7 +32,7 @@ const siteInfo: [string, string][] = [
 const PAGE_METADATA: PageMetadata = {
   title: 'Metadata',
   description:
-    'Technical metadata and comprehensive site statistics for dawidrylko.com. View build information, content inventory, page structure, and blog post directory—complete transparency into website architecture and content organization.',
+    'Technical metadata and site statistics for dawidrylko.com: build info, content inventory, page structure, and the full blog post directory.',
   keywords: [
     'site metadata',
     'website statistics',

--- a/src/pages/setup.astro
+++ b/src/pages/setup.astro
@@ -65,7 +65,7 @@ const image = {
 const PAGE_METADATA: PageMetadata = {
   title: 'Setup',
   description:
-    "Discover Dawid Ryłko's professional development workstation with segmented hardware stations and connection graph. Includes Mac mini M4 setup, ultrawide monitor, KVM switching, NAS storage and acoustic guitar equipment.",
+    "Dawid Ryłko's dev workstation: Mac mini M4, ultrawide monitor, KVM switching, Synology NAS, and a connection graph of the whole setup.",
   keywords: [
     'developer workstation',
     'hardware topology',


### PR DESCRIPTION
Addresses the Ahrefs Site Audit findings on the pages we control, and adds checks/tests so they cannot silently regress. Blog post `title`/`description` (author content from MDX frontmatter) are intentionally left unchanged for now — the length check only warns about them.

## Fixed

- **Canonical points to non-200** — `noindex` pages (the 404) no longer emit a `<link rel="canonical">` that would target a non-200 URL (`/404/`).
- **Title too long** — the homepage `<title>` now uses a short `titleTagline` (≤60 chars) instead of the long `author.jobTitle` (92 chars). The full role copy stays in Bio + JSON-LD.
- **Meta description too long** — shortened the descriptions for the static pages we own (`/`, `/bio/`, `/contact/`, `/setup/`, `/metadata/`, `/files/`, `/blog/`) and the site fallback to ≤160 chars, and removed the decimal-ASCII easter egg from search snippets.
- **Image file size too big** — featured-image `<Picture>` components now emit a WebP fallback instead of the heavy PNG/JPEG, and the blog-listing JSON-LD image is built from an optimised WebP (`getImage`) instead of the raw original, so referenced images ship as AVIF/WebP only.

## Guardrails added

- `src/lib/seo.ts` — pure title/description resolvers + `TITLE_MAX_LENGTH` / `DESCRIPTION_MAX_LENGTH`, with unit tests (`src/lib/seo.test.ts`).
- `helpers/ci/check-seo-lengths.mjs` — fails the build when an **app-owned** page exceeds the title/description limits; blog posts are warnings only.
- `helpers/ci/check-image-budget.mjs` (+ `image-budget-baseline.json`) — 1 MB per-image budget; existing post images are grandfathered, **new** oversized images fail CI.
- `check-seo-meta.mjs` now asserts `noindex` pages carry no canonical; smoke test asserts the same on the 404.
- New checks wired into the `build-contract` CI job; rules documented in `CLAUDE.md`.

## Verification

`pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check`, `pnpm test` (32 passing), `pnpm build`, and all `dist/` contracts pass locally. Playwright e2e runs in CI (Chromium download is blocked in the dev sandbox).