### PR TITLE
fix(seo): emit a single h1 per page and guard against regressions

### DIFF
--- a/helpers/ci/check-seo-meta.mjs
+++ b/helpers/ci/check-seo-meta.mjs
@@ -7,6 +7,7 @@
  *
  *   - a non-empty <title>
  *   - a non-empty <meta name="description">
+ *   - exactly one <h1> (SEO audits flag pages with zero or multiple H1s)
  *   - a <link rel="canonical"> pointing at the production origin
  *   - every <script type="application/ld+json"> block is valid JSON
  *
@@ -78,6 +79,12 @@ function checkPage(page, html) {
 
   const description = html.match(/<meta[^>]*name="description"[^>]*content="([^"]*)"/);
   if (!description || !description[1].trim()) fail(`${page}: missing or empty meta description`);
+
+  // Exactly one <h1> per page. Ahrefs flags both missing and multiple H1s; the
+  // usual regression is a React island (e.g. a demo) rendering its own <h1>
+  // inside an article that already has the post title as <h1>.
+  const h1Count = (html.match(/<h1[\s/>]/g) || []).length;
+  if (h1Count !== 1) fail(`${page}: expected exactly one <h1>, found ${h1Count}`);
 
   const canonical = html.match(/<link[^>]*rel="canonical"[^>]*href="([^"]*)"/);
   // noindex pages (e.g. the 404) must not carry a canonical at all: a self

--- a/src/demo/memoization-demo.tsx
+++ b/src/demo/memoization-demo.tsx
@@ -161,7 +161,7 @@ const MemoizationDemo: FC = () => {
       <div className="harry-potter-app-container">
         <div className="harry-potter-main-card">
           <header className="harry-potter-header">
-            <h1 className="harry-potter-title">🧙‍♂️ Dumbledore&apos;s Pensieve</h1>
+            <h2 className="harry-potter-title">🧙‍♂️ Dumbledore&apos;s Pensieve</h2>
             <p className="harry-potter-subtitle">React Memoization Demo with Horcrux Memories</p>
             <p className="harry-potter-description">
               Extract memories from Voldemort&apos;s Horcruxes. First extraction takes time due to magical processing,


### PR DESCRIPTION
The memoization demo island rendered its own h1, giving the memoizacja
post two H1s (Ahrefs "Multiple H1 tags"). Demote it to h2 so the post
title stays the only h1; the CSS class is unchanged so the styling is
untouched.

Extend check-seo-meta.mjs to assert exactly one h1 per rendered page in
dist/, so a stray island heading cannot silently regress.