### PR TITLE
feat: tag archives, reading UX, dynamic OG images, sitemap & CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,9 @@ jobs:
       - name: Verify image weight budget
         run: node helpers/ci/check-image-budget.mjs
 
+      - name: Verify JS bundle budget
+        run: node helpers/ci/check-bundle-budget.mjs
+
   # Internal link integrity across the built site (catches broken links and
   # broken redirects). External URLs are skipped to keep the gate deterministic.
   links:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,10 @@ jobs:
       - name: Check internal links
         run: pnpm dlx linkinator@6.1.2 dist --recurse --skip "^https?://(?!localhost)"
 
-  # Rendered-page audit (Lighthouse) of the app-owned pages: accessibility and
-  # SEO are gated; performance and best-practices are advisory. ubuntu-latest
-  # ships Chrome, which Lighthouse auto-detects.
+  # Rendered-page audit (Lighthouse) of the app-owned pages: accessibility, SEO
+  # and performance are gated (performance on the median of three runs);
+  # best-practices stays advisory. ubuntu-latest ships Chrome, which Lighthouse
+  # auto-detects.
   lighthouse:
     name: Lighthouse
     runs-on: ubuntu-latest

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,8 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
+import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import webmanifest from './src/integrations/webmanifest';
 
 // Content pipeline (migrated from Gatsby):
@@ -31,8 +33,23 @@ export default defineConfig({
     layout: 'constrained',
   },
   markdown: {
+    // rehype-slug adds id="" to every heading (Astro does not by default), so
+    // the in-post table of contents and shared deep links resolve. autolink then
+    // appends a hover "#" anchor; it is aria-hidden + tabindex -1 so it neither
+    // duplicates the heading in the a11y tree nor becomes a focus trap.
     remarkPlugins: [remarkMath],
-    rehypePlugins: [rehypeKatex],
+    rehypePlugins: [
+      rehypeKatex,
+      rehypeSlug,
+      [
+        rehypeAutolinkHeadings,
+        {
+          behavior: 'append',
+          properties: { className: ['heading-anchor'], ariaHidden: 'true', tabIndex: -1 },
+          content: { type: 'text', value: '#' },
+        },
+      ],
+    ],
     shikiConfig: {
       themes: { light: 'github-light', dark: 'github-dark' },
     },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,11 @@ import rehypeKatex from 'rehype-katex';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import webmanifest from './src/integrations/webmanifest';
+import { buildPostLastmodMap } from './src/lib/sitemap.ts';
+
+// Post lastmod dates (updatedDate ?? date), read from frontmatter so the sitemap
+// can advertise per-post freshness. Built once at config load.
+const postLastmod = await buildPostLastmodMap();
 
 // Content pipeline (migrated from Gatsby):
 //   - MDX with remark-math + rehype-katex (KaTeX, build-time SSR)
@@ -25,7 +30,36 @@ export default defineConfig({
   redirects: {
     '/resume': '/bio/',
   },
-  integrations: [mdx(), react(), sitemap(), webmanifest()],
+  integrations: [
+    mdx(),
+    react(),
+    sitemap({
+      // Enrich each entry: per-post lastmod from frontmatter, plus a priority
+      // hint by route type (homepage > blog listings > posts > tags).
+      serialize(item) {
+        const pathname = new URL(item.url).pathname;
+        const slug = pathname.replace(/^\/|\/$/g, '');
+        const lastmod = postLastmod.get(slug);
+
+        if (lastmod) item.lastmod = new Date(lastmod).toISOString();
+
+        if (pathname === '/') {
+          item.priority = 1.0;
+        } else if (pathname === '/blog/' || /^\/blog\/\d+\/$/.test(pathname)) {
+          item.priority = 0.8;
+        } else if (lastmod) {
+          item.priority = 0.7;
+        } else if (pathname.startsWith('/tags/')) {
+          item.priority = 0.4;
+        } else {
+          item.priority = 0.6;
+        }
+
+        return item;
+      },
+    }),
+    webmanifest(),
+  ],
   // Responsive images (stable in Astro 6): every <Image>/<Picture> and Markdown
   // image gets a srcset + sizes + responsive styles automatically. Replaces
   // Gatsby's gatsbyImageData FULL_WIDTH responsive output.

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -3,7 +3,7 @@ import AxeBuilder from '@axe-core/playwright';
 
 // axe-core scan per page — deeper than the design-token contrast audit: catches
 // ARIA, landmark, label and structural issues in the rendered DOM.
-const ROUTES = ['/', '/blog/', '/bio/', '/contact/', '/setup/', '/metadata/', '/files/'];
+const ROUTES = ['/', '/blog/', '/bio/', '/contact/', '/setup/', '/metadata/', '/files/', '/tags/'];
 
 for (const route of ROUTES) {
   test(`${route} has no detectable WCAG A/AA violations`, async ({ page }) => {

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+// Blog pagination: /blog/ is page 1, /blog/2/ … carry the rest. The pager marks
+// the current page and exposes prev/next, and every page lists posts.
+test('blog pagination renders page 2 and marks it current', async ({ page }) => {
+  const response = await page.goto('/blog/2/');
+  expect(response?.ok()).toBeTruthy();
+
+  await expect(page.locator('#blog-posts .post-list-item').first()).toBeVisible();
+
+  const current = page.locator('.pagination .is-current');
+  await expect(current).toHaveText('2');
+
+  // Page 2 must offer a way back to page 1 (the bare /blog/ URL).
+  await expect(page.locator('.pagination a[rel="prev"]')).toBeVisible();
+});
+
+test('pagination links move between pages', async ({ page }) => {
+  await page.goto('/blog/');
+  await expect(page.locator('.pagination .is-current')).toHaveText('1');
+
+  await page.locator('.pagination a[rel="next"]').click();
+  await expect(page).toHaveURL(/\/blog\/2\/$/);
+  await expect(page.locator('.pagination .is-current')).toHaveText('2');
+});
+
+// The Gatsby-era /resume → /bio/ redirect must keep working (meta-refresh stub).
+test('/resume redirects to /bio/', async ({ page }) => {
+  await page.goto('/resume/');
+  await page.waitForURL(/\/bio\/$/);
+  await expect(page.locator('h1')).toBeVisible();
+});

--- a/e2e/tags.spec.ts
+++ b/e2e/tags.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+// The tag index lists every tag and links to its archive; each archive lists the
+// tagged posts. Post-page tag chips point at these archives (crawlable, unlike
+// the JS-only blog search), so the index → archive → post path must hold.
+test('tag index links to an archive that lists posts', async ({ page }) => {
+  await page.goto('/tags/');
+  await expect(page.locator('h1')).toHaveText('Tagi');
+
+  const firstTag = page.locator('.tag-cloud a.tag').first();
+  const href = await firstTag.getAttribute('href');
+  expect(href).toMatch(/^\/tags\/[^/]+\/$/);
+
+  const response = await page.goto(href as string);
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.locator('h1')).toContainText('#');
+  await expect(page.locator('.posts .post-list-item').first()).toBeVisible();
+});
+
+test('a post tag chip leads to the matching tag archive', async ({ page }) => {
+  await page.goto('/blog/');
+  const firstPost = page.locator('#blog-posts .post-list-item h2 a').first();
+  await page.goto((await firstPost.getAttribute('href')) as string);
+
+  const tagChip = page.locator('article.blog-post .tags a.tag').first();
+  const href = await tagChip.getAttribute('href');
+  expect(href).toMatch(/^\/tags\/[^/]+\/$/);
+
+  const response = await page.goto(href as string);
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.locator('.posts .post-list-item').first()).toBeVisible();
+});

--- a/helpers/ci/README.md
+++ b/helpers/ci/README.md
@@ -51,6 +51,18 @@ node helpers/ci/check-image-budget.mjs                  # check
 node helpers/ci/check-image-budget.mjs --update-baseline # regenerate baseline
 ```
 
+## `check-bundle-budget.mjs`
+
+Fails when any single page references more than 240 KB of `/_astro/*.js` up front
+(module scripts + modulepreload links). Mermaid's per-diagram chunks load at
+runtime and are not counted. Catches a heavy dependency that starts shipping
+site-wide. Runs in the `build-contract` job.
+
+```bash
+pnpm build
+node helpers/ci/check-bundle-budget.mjs
+```
+
 ## `check-no-ai-attribution.mjs`
 
 Enforces the no-AI-attribution rule from `CLAUDE.md`: fails if a commit message

--- a/helpers/ci/check-astro-build-output.mjs
+++ b/helpers/ci/check-astro-build-output.mjs
@@ -175,6 +175,31 @@ async function checkMermaidOverflow(css) {
   }
 }
 
+async function checkTagArchives() {
+  // The tag index must exist and link out to at least one tag archive, and each
+  // archive must list posts via the shared .post-list-item card. Tag chips on
+  // post pages point at /tags/<slug>/, so a broken archive would 404 internally.
+  if (!(await exists('tags/index.html'))) {
+    fail('cannot check tags: tags/index.html missing (tag archive pages did not build)');
+    return;
+  }
+  const indexHtml = await read('tags/index.html');
+  const firstTag = indexHtml.match(/href="\/tags\/([^"/]+)\/"/);
+  if (!firstTag) {
+    fail('tags index lists no tag archives (/tags/<slug>/ links missing)');
+    return;
+  }
+  const archive = `tags/${firstTag[1]}/index.html`;
+  if (!(await exists(archive))) {
+    fail(`tag archive ${archive} missing (a /tags/ link points at a page that did not build)`);
+    return;
+  }
+  const archiveHtml = await read(archive);
+  if (!/class="post-list-item"/.test(archiveHtml)) {
+    fail('tag archive lists no posts (.post-list-item missing — shared card regressed)');
+  }
+}
+
 async function checkBlogThumbnail() {
   if (!(await exists('blog/index.html'))) {
     fail('cannot check blog thumbnails: blog/index.html missing');
@@ -205,6 +230,7 @@ async function main() {
   await checkMermaidOverflow(css);
   await checkDemoHydration();
   await checkBlogThumbnail();
+  await checkTagArchives();
   await checkFilesPage();
   await checkFilesHiddenToggle();
 
@@ -215,7 +241,7 @@ async function main() {
     process.exit(1);
   }
   console.log(
-    '  ✓ code dark theme, Mermaid hydration + overflow, demo hydration, thumbnails, list markers, breadcrumbs, files listing + toggle.',
+    '  ✓ code dark theme, Mermaid hydration + overflow, demo hydration, thumbnails, tag archives, list markers, breadcrumbs, files listing + toggle.',
   );
 }
 

--- a/helpers/ci/check-bundle-budget.mjs
+++ b/helpers/ci/check-bundle-budget.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * JS bundle budget for the Astro build (dist/).
+ *
+ * Guards the JavaScript a visitor downloads up front on any single page. For
+ * each rendered page it sums the unique /_astro/*.js modules the HTML references
+ * (module scripts + modulepreload links) and fails if the heaviest page exceeds
+ * the budget.
+ *
+ * Only statically-referenced modules count: Mermaid's per-diagram chunks are
+ * imported at runtime by the hydrated island, not preloaded in the HTML, so they
+ * are correctly excluded. Today the heaviest page is /setup/ (the Mermaid
+ * client:load island) at ~187 KB; the budget leaves headroom while still
+ * catching a heavy dependency that starts shipping site-wide.
+ *
+ * Zero dependencies; runs against the built output, it does NOT rebuild.
+ */
+
+import { readFile, readdir, access, stat } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : resolve(__dirname, '../../dist');
+
+const MAX_PAGE_JS_BYTES = 240 * 1024;
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Recursively collect every .html file under dir. */
+async function collectHtml(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return collectHtml(full);
+      return entry.name.endsWith('.html') ? [full] : [];
+    }),
+  );
+  return files.flat();
+}
+
+/** Sum the unique /_astro/*.js modules a page references, in bytes. */
+async function pageJsBytes(html, sizeCache) {
+  const refs = new Set(html.match(/\/_astro\/[A-Za-z0-9._-]+\.js/g) ?? []);
+  let total = 0;
+  for (const ref of refs) {
+    if (!sizeCache.has(ref)) {
+      try {
+        sizeCache.set(ref, (await stat(join(DIST_DIR, ref))).size);
+      } catch {
+        sizeCache.set(ref, 0);
+      }
+    }
+    total += sizeCache.get(ref);
+  }
+  return total;
+}
+
+async function main() {
+  if (!(await exists(DIST_DIR))) {
+    console.error(`Build output not found at ${DIST_DIR}. Run "pnpm build" first.`);
+    process.exit(1);
+  }
+
+  const pages = await collectHtml(DIST_DIR);
+  const sizeCache = new Map();
+  const weights = [];
+  for (const page of pages) {
+    const bytes = await pageJsBytes(await readFile(page, 'utf8'), sizeCache);
+    weights.push({ page: relative(DIST_DIR, page), bytes });
+  }
+  weights.sort((a, b) => b.bytes - a.bytes);
+
+  const kb = bytes => `${(bytes / 1024).toFixed(0)} KB`;
+  const over = weights.filter(w => w.bytes > MAX_PAGE_JS_BYTES);
+
+  console.log(`JS bundle budget (dist/) — max ${kb(MAX_PAGE_JS_BYTES)} per page\n`);
+  if (over.length > 0) {
+    for (const w of over) console.error(`  ✗ ${w.page}: ${kb(w.bytes)} of initial JS (over budget)`);
+    console.error(`\nBundle budget failed: ${over.length} page(s) over ${kb(MAX_PAGE_JS_BYTES)}.`);
+    process.exit(1);
+  }
+  const heaviest = weights[0];
+  console.log(`  ✓ ${pages.length} page(s) within budget (heaviest: ${heaviest.page} at ${kb(heaviest.bytes)}).`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/helpers/ci/check-seo-lengths.mjs
+++ b/helpers/ci/check-seo-lengths.mjs
@@ -30,9 +30,11 @@ const TITLE_MAX_LENGTH = 60;
 const DESCRIPTION_MAX_LENGTH = 160;
 
 // First path segment of every app-owned route. The homepage is '' (index.html);
-// blog covers the listing and its pagination (blog/, blog/2/, …). Everything
-// else (top-level post slugs, 404) is author content and only warned about.
-const OWNED_SEGMENTS = new Set(['', 'bio', 'contact', 'setup', 'metadata', 'files', 'blog']);
+// blog covers the listing and its pagination (blog/, blog/2/, …); tags covers
+// the tag index and each archive (titles/descriptions are app-generated from a
+// short tag label). Everything else (top-level post slugs, 404) is author
+// content and only warned about.
+const OWNED_SEGMENTS = new Set(['', 'bio', 'contact', 'setup', 'metadata', 'files', 'blog', 'tags']);
 
 const problems = [];
 const warnings = [];

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -7,11 +7,12 @@
  * regressions that static analysis cannot see.
  *
  * Responsibility split (no overlap with other CI jobs):
- *   - accessibility/seo are gated as errors here at the rendered-page level;
- *     the jsx-a11y lint and the design-token contrast gate cover the source
- *     and palette layers respectively.
- *   - performance/best-practices are advisory (warn) because scores vary on
- *     shared CI runners; they still surface meaningful drops in review.
+ *   - accessibility/seo/performance are gated as errors here at the
+ *     rendered-page level; the jsx-a11y lint and the design-token contrast gate
+ *     cover the source and palette layers respectively.
+ *   - performance is run three times and asserted on the median to absorb the
+ *     run-to-run variance of shared CI runners, so the gate is stable.
+ *   - best-practices stays advisory (warn); it still surfaces drops in review.
  */
 module.exports = {
   ci: {
@@ -24,7 +25,9 @@ module.exports = {
         'http://localhost:9000/setup/',
         'http://localhost:9000/metadata/',
       ],
-      numberOfRuns: 1,
+      // Three runs let Lighthouse CI assert on the median, smoothing the noise
+      // that made performance unsafe to gate on a single run.
+      numberOfRuns: 3,
       settings: {
         chromeFlags: '--no-sandbox',
       },
@@ -34,7 +37,7 @@ module.exports = {
         'categories:accessibility': ['error', { minScore: 0.95 }],
         'categories:seo': ['error', { minScore: 0.95 }],
         'categories:best-practices': ['warn', { minScore: 0.9 }],
-        'categories:performance': ['warn', { minScore: 0.8 }],
+        'categories:performance': ['error', { minScore: 0.8 }],
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "lint-staged": "^16.2.6",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-slug": "^6.0.0",
     "stylelint": "^17.13.0",
     "stylelint-config-standard": "^40.0.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,12 @@ importers:
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
+      rehype-autolink-headings:
+        specifier: ^7.1.0
+        version: 7.1.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       stylelint:
         specifier: ^17.13.0
         version: 17.13.0(typescript@6.0.3)
@@ -2491,6 +2497,9 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
@@ -2511,6 +2520,9 @@ packages:
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -3396,6 +3408,9 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  rehype-autolink-headings@7.1.0:
+    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
+
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
 
@@ -3407,6 +3422,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -6897,6 +6915,10 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -6985,6 +7007,10 @@ snapshots:
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-to-text@4.0.2:
     dependencies:
@@ -8153,6 +8179,15 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  rehype-autolink-headings@7.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.1
+      hast-util-heading-rank: 3.0.0
+      hast-util-is-element: 3.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
   rehype-katex@7.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -8182,6 +8217,14 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   rehype-stringify@10.0.1:
     dependencies:

--- a/src/components/PostListItem.astro
+++ b/src/components/PostListItem.astro
@@ -1,0 +1,82 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { Picture } from 'astro:assets';
+import { SITE_METADATA } from '../data/site-metadata';
+import { excerpt } from '../lib/excerpt';
+import { inlineMarkdown } from '../lib/inline-markdown';
+import { formatPolishDate } from '../lib/date';
+import { slugifyTag } from '../lib/tags';
+
+// Shared blog post card (one <li> in a .posts list). Used by the blog index and
+// the tag archives so the markup stays in one place.
+//
+// tagMode controls the tag chips:
+//   - 'link'   → real links to the tag archive (/tags/<slug>/); the default and
+//                the right choice everywhere except the blog index.
+//   - 'search' → the blog index's progressive-enhancement chips (data-tag drives
+//                the in-page search; href is the shareable /blog/?q= fallback).
+interface Props {
+  post: CollectionEntry<'posts'>;
+  tagMode?: 'link' | 'search';
+}
+
+const { post, tagMode = 'link' } = Astro.props;
+const author = SITE_METADATA.author;
+
+const description = post.data.description || excerpt(post.body ?? '');
+const descriptionHtml = inlineMarkdown(description);
+const dateFormatted = formatPolishDate(post.data.date);
+---
+
+<li>
+  <article class="post-list-item">
+    <header>
+      <h2>
+        <a href={`/${post.id}/`}>{post.data.title}</a>
+      </h2>
+      <small>
+        <span>{dateFormatted}</span>
+        &nbsp;|&nbsp;
+        <span>
+          <a href="/bio/">{author.name}</a>
+        </span>
+      </small>
+    </header>
+    <section>
+      {
+        post.data.featuredImg && (
+          <a href={`/${post.id}/`} class="post-thumb" aria-hidden="true" tabindex="-1">
+            <Picture
+              src={post.data.featuredImg}
+              formats={['avif', 'webp']}
+              fallbackFormat="webp"
+              width={600}
+              sizes="(min-width: 37.5rem) 200px, 100vw"
+              alt={post.data.featuredImgAlt || ''}
+            />
+          </a>
+        )
+      }
+      <p set:html={descriptionHtml} />
+    </section>
+    <ul class="tags" aria-label="Tagi">
+      {
+        post.data.tags.map(tag =>
+          tagMode === 'search' ? (
+            <li>
+              <a class="tag" href={`/blog/?q=${encodeURIComponent(tag)}`} data-tag={tag}>
+                #{tag}
+              </a>
+            </li>
+          ) : (
+            <li>
+              <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>
+                #{tag}
+              </a>
+            </li>
+          ),
+        )
+      }
+    </ul>
+  </article>
+</li>

--- a/src/lib/og-image.test.ts
+++ b/src/lib/og-image.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { wrapText, buildOgSvg } from './og-image';
+
+describe('wrapText', () => {
+  it('keeps short text on a single line', () => {
+    expect(wrapText('Hello world', 24, 4)).toEqual(['Hello world']);
+  });
+
+  it('wraps on spaces when a line would overflow', () => {
+    expect(wrapText('one two three four five', 9, 4)).toEqual(['one two', 'three', 'four five']);
+  });
+
+  it('keeps an over-long single word whole', () => {
+    expect(wrapText('superlongunbreakableword tail', 10, 4)).toEqual(['superlongunbreakableword', 'tail']);
+  });
+
+  it('ellipsises when the text exceeds the line budget', () => {
+    const lines = wrapText('a b c d e f g h i j', 1, 3);
+    expect(lines).toHaveLength(3);
+    expect(lines[2].endsWith('…')).toBe(true);
+  });
+});
+
+describe('buildOgSvg', () => {
+  it('produces a 1200x630 SVG containing the (escaped) title', () => {
+    const svg = buildOgSvg('Tags & <Astro>');
+    expect(svg).toContain('width="1200"');
+    expect(svg).toContain('height="630"');
+    expect(svg).toContain('Tags &amp; &lt;Astro&gt;');
+    expect(svg).not.toContain('<Astro>');
+  });
+});

--- a/src/lib/og-image.ts
+++ b/src/lib/og-image.ts
@@ -1,0 +1,84 @@
+import { SITE_METADATA } from '../data/site-metadata';
+
+// Open Graph card dimensions (the de-facto 1.91:1 standard).
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+// Title layout. Values are tuned for the generic sans-serif the rasteriser
+// falls back to; they leave margin so even the widest line stays on the card.
+const TITLE_FONT_SIZE = 64;
+const TITLE_LINE_HEIGHT = 82;
+const TITLE_MAX_CHARS = 24;
+const TITLE_MAX_LINES = 4;
+
+// Greedily wrap text into at most `maxLines` lines of roughly `maxChars` each,
+// breaking on spaces only (a word longer than the limit stays whole). When the
+// text does not fit, the last kept line is ellipsised.
+export function wrapText(text: string, maxChars: number, maxLines: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length <= maxChars || current === '') {
+      current = candidate;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+
+  if (lines.length <= maxLines) return lines;
+
+  const kept = lines.slice(0, maxLines);
+  const last = kept[maxLines - 1];
+  kept[maxLines - 1] = `${last.length > maxChars - 1 ? last.slice(0, maxChars - 1).trimEnd() : last}…`;
+  return kept;
+}
+
+const escapeXml = (value: string): string =>
+  value.replace(/[&<>"']/g, char => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      default:
+        return '&#39;';
+    }
+  });
+
+// Build the OG card SVG: brand-coloured background, a small eyebrow, the wrapped
+// post title and a footer with the site name. Exported for testing/inspection.
+export function buildOgSvg(title: string): string {
+  const lines = wrapText(title, TITLE_MAX_CHARS, TITLE_MAX_LINES);
+  const blockHeight = lines.length * TITLE_LINE_HEIGHT;
+  const startY = (HEIGHT - blockHeight) / 2 + TITLE_FONT_SIZE;
+
+  const tspans = lines
+    .map((line, index) => `<tspan x="80" y="${startY + index * TITLE_LINE_HEIGHT}">${escapeXml(line)}</tspan>`)
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="#005b99"/>
+  <rect width="${WIDTH}" height="12" fill="#5eb3f0"/>
+  <text x="80" y="120" font-family="sans-serif" font-size="32" font-weight="700" letter-spacing="4" fill="#a9d3f2">BLOG</text>
+  <text font-family="sans-serif" font-size="${TITLE_FONT_SIZE}" font-weight="700" fill="#ffffff">${tspans}</text>
+  <text x="80" y="560" font-family="sans-serif" font-size="32" fill="#d1dce5">${escapeXml(SITE_METADATA.author.name)} · dawidrylko.com</text>
+</svg>`;
+}
+
+// Rasterise the OG card to a PNG buffer. sharp is imported lazily so the unit
+// tests (which only exercise the pure helpers) never load the native binding.
+export async function renderOgImage(title: string): Promise<Buffer> {
+  const { default: sharp } = await import('sharp');
+  return sharp(Buffer.from(buildOgSvg(title)))
+    .png()
+    .toBuffer();
+}

--- a/src/lib/pl-plural.test.ts
+++ b/src/lib/pl-plural.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { plPlural } from './pl-plural';
+
+const forms: [string, string, string] = ['minuta', 'minuty', 'minut'];
+
+describe('plPlural', () => {
+  it('uses the singular for exactly 1', () => {
+    expect(plPlural(1, forms)).toBe('minuta');
+  });
+
+  it('uses the "few" form for 2-4 (not the teens)', () => {
+    expect(plPlural(2, forms)).toBe('minuty');
+    expect(plPlural(3, forms)).toBe('minuty');
+    expect(plPlural(4, forms)).toBe('minuty');
+    expect(plPlural(23, forms)).toBe('minuty');
+  });
+
+  it('uses the "many" form for 0, 5+, and the teens', () => {
+    expect(plPlural(0, forms)).toBe('minut');
+    expect(plPlural(5, forms)).toBe('minut');
+    expect(plPlural(11, forms)).toBe('minut');
+    expect(plPlural(12, forms)).toBe('minut');
+    expect(plPlural(14, forms)).toBe('minut');
+    expect(plPlural(100, forms)).toBe('minut');
+  });
+});

--- a/src/lib/pl-plural.ts
+++ b/src/lib/pl-plural.ts
@@ -1,0 +1,11 @@
+// Polish has three plural forms. Pick the right one for a count:
+//   - one:  n === 1                         (1 minuta)
+//   - few:  n % 10 in 2..4 and not 12..14   (2 minuty, 23 minuty)
+//   - many: everything else                 (5 minut, 11 minut, 100 minut)
+export function plPlural(n: number, [one, few, many]: [string, string, string]): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (n === 1) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
+}

--- a/src/lib/reading-time.test.ts
+++ b/src/lib/reading-time.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { countWords, readingTimeMinutes } from './reading-time';
+
+describe('countWords', () => {
+  it('returns 0 for empty or missing input', () => {
+    expect(countWords()).toBe(0);
+    expect(countWords('')).toBe(0);
+    expect(countWords('   ')).toBe(0);
+  });
+
+  it('counts whitespace-separated words', () => {
+    expect(countWords('one two three')).toBe(3);
+    expect(countWords('  spaced   out \n words ')).toBe(3);
+  });
+
+  it('ignores fenced code blocks', () => {
+    const body = 'intro words here\n```js\nconst a = 1;\nconst b = 2;\n```\noutro words';
+    expect(countWords(body)).toBe(5);
+  });
+});
+
+describe('readingTimeMinutes', () => {
+  it('rounds to whole minutes', () => {
+    expect(readingTimeMinutes(200)).toBe(1);
+    expect(readingTimeMinutes(500)).toBe(3);
+  });
+
+  it('never returns less than 1 minute', () => {
+    expect(readingTimeMinutes(0)).toBe(1);
+    expect(readingTimeMinutes(10)).toBe(1);
+  });
+});

--- a/src/lib/reading-time.ts
+++ b/src/lib/reading-time.ts
@@ -1,0 +1,20 @@
+// Average adult reading speed (words per minute). A round, widely-used estimate;
+// the figure is approximate so a precise value would be false precision.
+const WORDS_PER_MINUTE = 200;
+
+// Count words in a Markdown body, stripping fenced code blocks first (code is
+// scanned, not read linearly, so counting it inflates the estimate). Mirrors the
+// approximation that used to live inline in the post page.
+export function countWords(body?: string): number {
+  if (!body) return 0;
+  return body
+    .replace(/```[\s\S]*?```/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+// Whole-minute reading estimate, floored at 1 so a short post never reads "0 min".
+export function readingTimeMinutes(words: number): number {
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}

--- a/src/lib/related-posts.test.ts
+++ b/src/lib/related-posts.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { relatedPosts } from './related-posts';
+
+const post = (id: string, date: string, tags: string[]) => ({ id, data: { date: new Date(date), tags } });
+
+const current = post('current', '2025-01-01', ['js', 'astro']);
+
+describe('relatedPosts', () => {
+  it('ranks by shared tag count, then by date (newest first)', () => {
+    const candidates = [
+      post('one-shared-old', '2020-01-01', ['js']),
+      post('two-shared', '2019-01-01', ['js', 'astro']),
+      post('one-shared-new', '2024-01-01', ['astro']),
+    ];
+    const result = relatedPosts(current, candidates).map(p => p.id);
+    expect(result).toEqual(['two-shared', 'one-shared-new', 'one-shared-old']);
+  });
+
+  it('excludes the current post and posts with no shared tags', () => {
+    const candidates = [current, post('unrelated', '2025-01-01', ['python']), post('related', '2025-01-01', ['js'])];
+    const result = relatedPosts(current, candidates).map(p => p.id);
+    expect(result).toEqual(['related']);
+  });
+
+  it('caps the result at the requested limit', () => {
+    const candidates = [
+      post('a', '2025-01-01', ['js']),
+      post('b', '2025-01-02', ['js']),
+      post('c', '2025-01-03', ['js']),
+      post('d', '2025-01-04', ['js']),
+    ];
+    expect(relatedPosts(current, candidates, 2)).toHaveLength(2);
+  });
+
+  it('returns an empty array when nothing is related', () => {
+    expect(relatedPosts(current, [post('x', '2025-01-01', ['go'])])).toEqual([]);
+  });
+});

--- a/src/lib/related-posts.ts
+++ b/src/lib/related-posts.ts
@@ -1,0 +1,22 @@
+// Minimal shape needed to rank posts by relatedness; satisfied by a content
+// collection entry, so the helper stays pure and unit-testable without pulling
+// in astro:content.
+interface RankablePost {
+  id: string;
+  data: { date: Date; tags: string[] };
+}
+
+// Posts most related to `current`, ranked by number of shared tags (desc) and,
+// on a tie, by date (newest first). The current post is excluded and only posts
+// sharing at least one tag qualify. Returns at most `limit` entries.
+export function relatedPosts<T extends RankablePost>(current: T, candidates: T[], limit = 3): T[] {
+  const currentTags = new Set(current.data.tags);
+
+  return candidates
+    .filter(post => post.id !== current.id)
+    .map(post => ({ post, shared: post.data.tags.filter(tag => currentTags.has(tag)).length }))
+    .filter(({ shared }) => shared > 0)
+    .sort((a, b) => b.shared - a.shared || b.post.data.date.getTime() - a.post.data.date.getTime())
+    .slice(0, limit)
+    .map(({ post }) => post);
+}

--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { postSlug, lastmodFromFrontmatter } from './sitemap';
+
+describe('postSlug', () => {
+  it('strips the YYYY-MM-DD-- date prefix', () => {
+    expect(postSlug('2025-12-26--od-tablicy-do-mapy')).toBe('od-tablicy-do-mapy');
+    expect(postSlug('2017-03-19--angular-2-angular-cli-pierwsze-kroki')).toBe('angular-2-angular-cli-pierwsze-kroki');
+  });
+});
+
+describe('lastmodFromFrontmatter', () => {
+  it('returns the date day from a full ISO timestamp', () => {
+    expect(lastmodFromFrontmatter('date: 2016-04-16T13:31:30.000Z')).toBe('2016-04-16');
+  });
+
+  it('prefers updatedDate over date', () => {
+    const fm = 'date: 2016-04-16T13:31:30.000Z\nupdatedDate: 2020-01-02T00:00:00.000Z';
+    expect(lastmodFromFrontmatter(fm)).toBe('2020-01-02');
+  });
+
+  it('handles quoted and date-only values', () => {
+    expect(lastmodFromFrontmatter("date: '2021-05-05'")).toBe('2021-05-05');
+    expect(lastmodFromFrontmatter('date: 2021-05-05')).toBe('2021-05-05');
+  });
+
+  it('returns null when no date is present', () => {
+    expect(lastmodFromFrontmatter('title: Something')).toBeNull();
+  });
+});

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,41 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Derive the URL slug for a top-level post directory. Mirrors generateId in
+// content.config.ts: strip the leading YYYY-MM-DD-- prefix.
+export function postSlug(dirName: string): string {
+  return dirName.replace(/.*--/, '');
+}
+
+// The sitemap lastmod for a post: updatedDate if present, otherwise date, as a
+// yyyy-mm-dd string (the day is enough for crawlers). Null when neither is found.
+export function lastmodFromFrontmatter(frontmatter: string): string | null {
+  const date = frontmatter.match(/^date:\s*['"]?(\d{4}-\d{2}-\d{2})/m)?.[1];
+  const updated = frontmatter.match(/^updatedDate:\s*['"]?(\d{4}-\d{2}-\d{2})/m)?.[1];
+  return updated ?? date ?? null;
+}
+
+// Map each top-level post slug to its lastmod by reading frontmatter directly
+// from disk. Used by the sitemap serializer in astro.config.mjs, which runs
+// outside the Astro content pipeline and so cannot use getCollection().
+export async function buildPostLastmodMap(baseDir = 'content/pl'): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const dirs = await readdir(baseDir, { withFileTypes: true });
+
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue;
+    for (const file of ['index.mdx', 'index.md']) {
+      try {
+        const raw = await readFile(join(baseDir, dir.name, file), 'utf8');
+        const frontmatter = raw.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+        const lastmod = lastmodFromFrontmatter(frontmatter);
+        if (lastmod) map.set(postSlug(dir.name), lastmod);
+        break;
+      } catch {
+        // Try the other extension; a directory may hold index.md or index.mdx.
+      }
+    }
+  }
+
+  return map;
+}

--- a/src/lib/tags.test.ts
+++ b/src/lib/tags.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __setEntries, type MockPost } from '../../test/mocks/astro-content';
+import { slugifyTag, getTags } from './tags';
+
+const post = (id: string, date: string, tags: string[]): MockPost => ({ id, data: { date: new Date(date), tags } });
+
+describe('slugifyTag', () => {
+  it('lowercases and keeps simple tags', () => {
+    expect(slugifyTag('JavaScript')).toBe('javascript');
+    expect(slugifyTag('css')).toBe('css');
+  });
+
+  it('collapses dots and spaces into single hyphens', () => {
+    expect(slugifyTag('Node.js')).toBe('node-js');
+    expect(slugifyTag('frontend development')).toBe('frontend-development');
+    expect(slugifyTag('shopping   manager')).toBe('shopping-manager');
+  });
+
+  it('strips Polish diacritics (including ł)', () => {
+    expect(slugifyTag('Łódź')).toBe('lodz');
+    expect(slugifyTag('Zażółć')).toBe('zazolc');
+  });
+
+  it('trims leading and trailing separators', () => {
+    expect(slugifyTag('C++')).toBe('c');
+    expect(slugifyTag('.NET')).toBe('net');
+  });
+});
+
+describe('getTags', () => {
+  beforeEach(() => __setEntries([]));
+
+  it('aggregates tags with counts and sorts by frequency then name', async () => {
+    __setEntries([
+      post('a', '2025-01-01', ['css', 'javascript']),
+      post('b', '2025-02-01', ['javascript', 'angular']),
+      post('c', '2025-03-01', ['javascript']),
+    ]);
+    const tags = await getTags();
+    expect(tags.map(t => [t.tag, t.count, t.slug])).toEqual([
+      ['javascript', 3, 'javascript'],
+      ['angular', 1, 'angular'],
+      ['css', 1, 'css'],
+    ]);
+  });
+
+  it('keeps posts newest-first within a tag (getBlogPosts order)', async () => {
+    __setEntries([post('old', '2024-01-01', ['go']), post('new', '2025-01-01', ['go'])]);
+    const [go] = await getTags();
+    expect(go.posts.map(p => p.id)).toEqual(['new', 'old']);
+  });
+
+  it('ignores nested secondary pages (via getBlogPosts filter)', async () => {
+    __setEntries([post('first', '2025-01-01', ['css']), post('first/ng-help', '2025-01-02', ['css'])]);
+    const [css] = await getTags();
+    expect(css.count).toBe(1);
+  });
+
+  it('throws on a slug collision between two distinct tags', async () => {
+    __setEntries([post('a', '2025-01-01', ['C++', 'C#'])]);
+    await expect(getTags()).rejects.toThrow(/slug collision/);
+  });
+});

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,62 @@
+import { getBlogPosts } from './blog';
+
+// A blog post entry, inferred from getBlogPosts so this stays in sync with the
+// content collection type without importing astro:content directly (the unit
+// tests alias that virtual module to a stub).
+type Post = Awaited<ReturnType<typeof getBlogPosts>>[number];
+
+export interface TagInfo {
+  // The tag exactly as authored in frontmatter (display label).
+  tag: string;
+  // URL-safe slug used for /tags/<slug>/.
+  slug: string;
+  // Number of posts carrying the tag.
+  count: number;
+  // Posts carrying the tag, newest first (getBlogPosts order is preserved).
+  posts: Post[];
+}
+
+// Build a URL-safe slug for a tag. Mirrors the blog search normaliser
+// (lowercase, strip diacritics, ł→l — ł is not a decomposable combining mark)
+// then collapses every run of non-alphanumeric characters to a single hyphen so
+// "Node.js" → "node-js" and "frontend development" → "frontend-development".
+export function slugifyTag(tag: string): string {
+  return tag
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/ł/g, 'l')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Aggregate every tag across the published posts. Returns one entry per distinct
+// tag, sorted by frequency (desc) then alphabetically (pl locale). Throws if two
+// different tags slugify to the same URL so a collision fails the build rather
+// than silently merging two archives.
+export async function getTags(): Promise<TagInfo[]> {
+  const posts = await getBlogPosts();
+  const byTag = new Map<string, TagInfo>();
+  const slugOwner = new Map<string, string>();
+
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      const existing = byTag.get(tag);
+      if (existing) {
+        existing.posts.push(post);
+        existing.count += 1;
+        continue;
+      }
+
+      const slug = slugifyTag(tag);
+      const owner = slugOwner.get(slug);
+      if (owner && owner !== tag) {
+        throw new Error(`Tag slug collision: "${tag}" and "${owner}" both map to "/tags/${slug}/"`);
+      }
+      slugOwner.set(slug, tag);
+      byTag.set(tag, { tag, slug, count: 1, posts: [post] });
+    }
+  }
+
+  return [...byTag.values()].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag, 'pl'));
+}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -3,12 +3,14 @@ import { getCollection, render } from 'astro:content';
 import { Picture, getImage } from 'astro:assets';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
+import PostListItem from '../components/PostListItem.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
 import { formatPolishDate, toISODate } from '../lib/date';
 import { slugifyTag } from '../lib/tags';
 import { countWords, readingTimeMinutes } from '../lib/reading-time';
 import { plPlural } from '../lib/pl-plural';
+import { relatedPosts } from '../lib/related-posts';
 
 export async function getStaticPaths() {
   // Replicates Gatsby's createPages exactly: posts ordered by frontmatter date
@@ -16,6 +18,9 @@ export async function getStaticPaths() {
   // "next" is the newer one (posts[i+1]). Logic lives inside getStaticPaths
   // because Astro runs it in an isolated scope.
   const posts = (await getCollection('posts')).sort((a, b) => a.data.date.getTime() - b.data.date.getTime());
+  // Related posts are drawn from top-level entries only (secondary pages such as
+  // .../ng-help never appear in listings).
+  const topLevel = posts.filter(entry => !entry.id.includes('/'));
 
   return posts.map((post, index) => {
     const older = index > 0 ? posts[index - 1] : undefined;
@@ -26,12 +31,13 @@ export async function getStaticPaths() {
         post,
         previous: older ? { slug: older.id, title: older.data.title } : null,
         next: newer ? { slug: newer.id, title: newer.data.title } : null,
+        related: relatedPosts(post, topLevel, 3),
       },
     };
   });
 }
 
-const { post, previous, next } = Astro.props;
+const { post, previous, next, related } = Astro.props;
 const { Content, headings } = await render(post);
 
 // Table of contents from the post's h2/h3 headings (ids come from rehype-slug).
@@ -147,6 +153,19 @@ const structuredData = {
       }
     </ul>
   </article>
+
+  {
+    related.length > 0 && (
+      <section class="related" aria-label="Powiązane wpisy">
+        <h2>Powiązane wpisy</h2>
+        <ol class="posts">
+          {related.map(relatedPost => (
+            <PostListItem post={relatedPost} />
+          ))}
+        </ol>
+      </section>
+    )
+  }
 
   <nav class="blog-post-nav">
     <ul>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -52,11 +52,24 @@ const { person } = STRUCTURED_DATA;
 const publishedTime = toISODate(date);
 const modifiedTime = updatedDate ? toISODate(updatedDate) : undefined;
 
-// Open Graph wants a bounded image, not the raw (often multi-thousand-px) source.
-const ogImage = featuredImg ? (await getImage({ src: featuredImg, width: 1200, format: 'webp' })).src : undefined;
-// Preserve the source aspect ratio so OG image dimensions are accurate.
-const ogImageWidth = featuredImg ? 1200 : undefined;
-const ogImageHeight = featuredImg ? Math.round((1200 * featuredImg.height) / featuredImg.width) : undefined;
+// Open Graph image. Posts with a featuredImg use a bounded copy of it; top-level
+// posts without one fall back to a generated brand card (/og/<slug>.png, emitted
+// by src/pages/og/[slug].png.ts). Secondary pages (id with a slash) get no card
+// and fall back to the brand icon in <Seo>.
+const hasGeneratedOg = !featuredImg && !post.id.includes('/');
+const ogImage = featuredImg
+  ? (await getImage({ src: featuredImg, width: 1200, format: 'webp' })).src
+  : hasGeneratedOg
+    ? `/og/${post.id}.png`
+    : undefined;
+// Preserve the source aspect ratio so OG image dimensions are accurate; the
+// generated card is a fixed 1200×630.
+const ogImageWidth = featuredImg ? 1200 : hasGeneratedOg ? 1200 : undefined;
+const ogImageHeight = featuredImg
+  ? Math.round((1200 * featuredImg.height) / featuredImg.width)
+  : hasGeneratedOg
+    ? 630
+    : undefined;
 
 // Approximate word count from the raw Markdown body (strips fenced code first)
 // and the derived reading-time estimate shown in the post header.

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -32,7 +32,12 @@ export async function getStaticPaths() {
 }
 
 const { post, previous, next } = Astro.props;
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
+
+// Table of contents from the post's h2/h3 headings (ids come from rehype-slug).
+// Shown only when there is enough structure to be worth navigating.
+const tocHeadings = headings.filter(heading => heading.depth === 2 || heading.depth === 3);
+const showToc = tocHeadings.length >= 3;
 const { title, description, date, updatedDate, tags, featuredImg, featuredImgAlt } = post.data;
 
 const dateFormatted = formatPolishDate(date);
@@ -111,6 +116,20 @@ const structuredData = {
           layout="full-width"
           alt={featuredImgAlt ?? ''}
         />
+      )
+    }
+    {
+      showToc && (
+        <nav class="toc" aria-label="Spis treści">
+          <h2 class="toc-title">Spis treści</h2>
+          <ol>
+            {tocHeadings.map(heading => (
+              <li class={`toc-depth-${heading.depth}`}>
+                <a href={`#${heading.slug}`}>{heading.text}</a>
+              </li>
+            ))}
+          </ol>
+        </nav>
       )
     }
     <section>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -6,6 +6,7 @@ import JsonLd from '../components/JsonLd.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
 import { formatPolishDate, toISODate } from '../lib/date';
+import { slugifyTag } from '../lib/tags';
 
 export async function getStaticPaths() {
   // Replicates Gatsby's createPages exactly: posts ordered by frontmatter date
@@ -118,7 +119,7 @@ const structuredData = {
       {
         tags.map(tag => (
           <li>
-            <a class="tag" href={`/blog/?q=${encodeURIComponent(tag)}`}>
+            <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>
               #{tag}
             </a>
           </li>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -77,6 +77,12 @@ const words = countWords(post.body);
 const wordCount = words || undefined;
 const readingTime = readingTimeMinutes(words);
 
+// Share targets: static intent URLs (no third-party widgets/scripts) plus a
+// copy-link button wired up by the inline script below.
+const shareUrl = new URL(Astro.url.pathname, SITE_METADATA.url).href;
+const shareOnX = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(shareUrl)}`;
+const shareOnLinkedIn = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'BlogPosting',
@@ -165,6 +171,12 @@ const structuredData = {
         ))
       }
     </ul>
+    <div class="share">
+      <span class="share-label">Udostępnij:</span>
+      <a class="share-link" href={shareOnX} target="_blank" rel="noopener noreferrer nofollow">X</a>
+      <a class="share-link" href={shareOnLinkedIn} target="_blank" rel="noopener noreferrer nofollow">LinkedIn</a>
+      <button class="share-link share-copy" type="button" data-share-url={shareUrl}>Kopiuj link</button>
+    </div>
   </article>
 
   {
@@ -203,3 +215,21 @@ const structuredData = {
     </ul>
   </nav>
 </PageLayout>
+
+<script>
+  // Copy-link button: writes the post URL to the clipboard with brief feedback.
+  // Progressive enhancement — the share intent links work without it.
+  const button = document.querySelector<HTMLButtonElement>('.share-copy');
+  if (button) {
+    const original = button.textContent;
+    button.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(button.dataset.shareUrl ?? location.href);
+        button.textContent = 'Skopiowano!';
+        window.setTimeout(() => (button.textContent = original), 2000);
+      } catch {
+        // Clipboard API unavailable (e.g. insecure context); leave the label.
+      }
+    });
+  }
+</script>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -7,6 +7,8 @@ import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
 import { formatPolishDate, toISODate } from '../lib/date';
 import { slugifyTag } from '../lib/tags';
+import { countWords, readingTimeMinutes } from '../lib/reading-time';
+import { plPlural } from '../lib/pl-plural';
 
 export async function getStaticPaths() {
   // Replicates Gatsby's createPages exactly: posts ordered by frontmatter date
@@ -45,14 +47,11 @@ const ogImage = featuredImg ? (await getImage({ src: featuredImg, width: 1200, f
 const ogImageWidth = featuredImg ? 1200 : undefined;
 const ogImageHeight = featuredImg ? Math.round((1200 * featuredImg.height) / featuredImg.width) : undefined;
 
-// Approximate word count from the raw Markdown body (strips fenced code first).
-const wordCount = post.body
-  ? post.body
-      .replace(/```[\s\S]*?```/g, ' ')
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean).length
-  : undefined;
+// Approximate word count from the raw Markdown body (strips fenced code first)
+// and the derived reading-time estimate shown in the post header.
+const words = countWords(post.body);
+const wordCount = words || undefined;
+const readingTime = readingTimeMinutes(words);
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -99,6 +98,8 @@ const structuredData = {
         <span>{dateFormatted}</span>
         &nbsp;|&nbsp;
         <span><a href="/bio/">{SITE_METADATA.author.name}</a></span>
+        &nbsp;|&nbsp;
+        <span>{readingTime} min czytania &middot; {words} {plPlural(words, ['słowo', 'słowa', 'słów'])}</span>
       </small>
     </header>
     {

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,16 +1,16 @@
 ---
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
-import { Image, Picture, getImage } from 'astro:assets';
+import { Image, getImage } from 'astro:assets';
 import PageLayout from '../../layouts/PageLayout.astro';
 import JsonLd from '../../components/JsonLd.astro';
+import PostListItem from '../../components/PostListItem.astro';
 import rssIcon from '../../assets/rss.svg';
 import { SITE_METADATA } from '../../data/site-metadata';
 import { STRUCTURED_DATA } from '../../data/structured-data';
 import { excerpt } from '../../lib/excerpt';
-import { inlineMarkdown } from '../../lib/inline-markdown';
 import { getBlogPosts, POSTS_PER_PAGE } from '../../lib/blog';
-import { formatPolishDate, toISODate } from '../../lib/date';
+import { toISODate } from '../../lib/date';
 
 const PAGE_METADATA = {
   title: 'Blog 🇵🇱',
@@ -48,9 +48,7 @@ const { person } = STRUCTURED_DATA;
 
 const items = page.data.map(post => {
   const description = post.data.description || excerpt(post.body ?? '');
-  const descriptionHtml = inlineMarkdown(description);
-  const dateFormatted = formatPolishDate(post.data.date);
-  return { post, description, descriptionHtml, dateFormatted };
+  return { post, description };
 });
 
 // Optimised WebP URL per post for the JSON-LD image, keyed by post id. Using the
@@ -103,6 +101,8 @@ const structuredData = {
   <div class="rss">
     <Image src={rssIcon} alt="Ikona RSS" width={20} height={20} layout="fixed" />
     <a href="/rss.xml" type="application/rss+xml">Subskrybuj kanał RSS</a>
+    &nbsp;|&nbsp;
+    <a href="/tags/">Przeglądaj tagi</a>
   </div>
 
   <search class="blog-search">
@@ -122,50 +122,7 @@ const structuredData = {
   <ol id="blog-search-results" class="posts" hidden></ol>
 
   <ol id="blog-posts" class="posts">
-    {
-      items.map(({ post, descriptionHtml, dateFormatted }) => (
-        <li>
-          <article class="post-list-item">
-            <header>
-              <h2>
-                <a href={`/${post.id}/`}>{post.data.title}</a>
-              </h2>
-              <small>
-                <span>{dateFormatted}</span>
-                &nbsp;|&nbsp;
-                <span>
-                  <a href="/bio/">{author.name}</a>
-                </span>
-              </small>
-            </header>
-            <section>
-              {post.data.featuredImg && (
-                <a href={`/${post.id}/`} class="post-thumb" aria-hidden="true" tabindex="-1">
-                  <Picture
-                    src={post.data.featuredImg}
-                    formats={['avif', 'webp']}
-                    fallbackFormat="webp"
-                    width={600}
-                    sizes="(min-width: 37.5rem) 200px, 100vw"
-                    alt={post.data.featuredImgAlt || ''}
-                  />
-                </a>
-              )}
-              <p set:html={descriptionHtml} />
-            </section>
-            <ul class="tags" aria-label="Tagi">
-              {post.data.tags.map(tag => (
-                <li>
-                  <a class="tag" href={`/blog/?q=${encodeURIComponent(tag)}`} data-tag={tag}>
-                    #{tag}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </article>
-        </li>
-      ))
-    }
+    {items.map(({ post }) => <PostListItem post={post} tagMode="search" />)}
   </ol>
 
   {

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -8,7 +8,7 @@ import type { PageMetadata } from '../types';
 
 // Static (non-blog) routes provided by src/pages. The Gatsby version queried
 // allSitePage; here the set is explicit since it changes rarely.
-const staticPages = ['/', '/404.html', '/bio/', '/blog/', '/contact/', '/files/', '/metadata/', '/setup/'];
+const staticPages = ['/', '/404.html', '/bio/', '/blog/', '/contact/', '/files/', '/metadata/', '/setup/', '/tags/'];
 
 const blogPaths = (await getCollection('posts'))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())

--- a/src/pages/og/[slug].png.ts
+++ b/src/pages/og/[slug].png.ts
@@ -1,0 +1,23 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+import { renderOgImage } from '../../lib/og-image';
+
+// Generate a branded Open Graph card for every top-level post that has no
+// featuredImg, so social/LLM previews show the title instead of the generic
+// brand icon. Posts WITH a featuredImg use that image and are skipped here.
+export const getStaticPaths = (async () => {
+  const posts = await getCollection('posts');
+  return posts
+    .filter(post => !post.id.includes('/') && !post.data.featuredImg)
+    .map(post => ({ params: { slug: post.id }, props: { title: post.data.title } }));
+}) satisfies GetStaticPaths;
+
+export const GET: APIRoute = async ({ props }) => {
+  const png = await renderOgImage(props.title as string);
+  return new Response(new Uint8Array(png), {
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+};

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -1,0 +1,69 @@
+---
+import type { GetStaticPaths } from 'astro';
+import PageLayout from '../../layouts/PageLayout.astro';
+import JsonLd from '../../components/JsonLd.astro';
+import PostListItem from '../../components/PostListItem.astro';
+import { SITE_METADATA } from '../../data/site-metadata';
+import { createPageSchema } from '../../lib/page-metadata';
+import { getTags, type TagInfo } from '../../lib/tags';
+import { toISODate } from '../../lib/date';
+
+export const getStaticPaths = (async () => {
+  const tags = await getTags();
+  return tags.map(tag => ({ params: { slug: tag.slug }, props: { tag } }));
+}) satisfies GetStaticPaths;
+
+interface Props {
+  tag: TagInfo;
+}
+
+const { tag } = Astro.props;
+
+const title = `Tag: ${tag.tag}`;
+const description = `Wpisy oznaczone tagiem „${tag.tag}” na blogu Dawida Ryłko — ${tag.count} ${
+  tag.count === 1 ? 'wpis' : 'wpisów'
+}.`;
+
+const structuredData = createPageSchema({
+  type: 'CollectionPage',
+  title,
+  description,
+  keywords: [tag.tag],
+  extra: {
+    mainEntity: {
+      '@type': 'ItemList',
+      name: title,
+      numberOfItems: tag.count,
+      itemListElement: tag.posts.map((post, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        url: `${SITE_METADATA.url}/${post.id}/`,
+        name: post.data.title,
+      })),
+    },
+    about: { '@type': 'Thing', name: tag.tag },
+    dateModified: toISODate(tag.posts[0].data.date),
+  },
+});
+---
+
+<PageLayout
+  breadcrumbTitle={title}
+  breadcrumbParents={[
+    { name: 'Blog 🇵🇱', url: '/blog/' },
+    { name: 'Tagi', url: '/tags/' },
+  ]}
+  title={title}
+  description={description}
+  lang="pl"
+>
+  <JsonLd data={structuredData} />
+  <header>
+    <h1>#{tag.tag}</h1>
+    <small>{tag.count} {tag.count === 1 ? 'wpis' : 'wpisów'}</small>
+  </header>
+  <ol class="posts">
+    {tag.posts.map(post => <PostListItem post={post} />)}
+  </ol>
+  <p><a href="/tags/">← Wszystkie tagi</a></p>
+</PageLayout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,62 @@
+---
+import PageLayout from '../../layouts/PageLayout.astro';
+import JsonLd from '../../components/JsonLd.astro';
+import { SITE_METADATA } from '../../data/site-metadata';
+import { createPageSchema } from '../../lib/page-metadata';
+import { getTags } from '../../lib/tags';
+import type { PageMetadata } from '../../types';
+
+const tags = await getTags();
+
+const PAGE_METADATA: PageMetadata = {
+  title: 'Tagi',
+  description:
+    'Wszystkie tagi bloga Dawida Ryłko — przeglądaj wpisy o programowaniu, technologiach i wytwarzaniu oprogramowania według tematu.',
+  keywords: ['tagi', 'tematy', 'kategorie', 'blog programistyczny', 'artykuły IT'],
+};
+
+const structuredData = createPageSchema({
+  type: 'CollectionPage',
+  title: PAGE_METADATA.title,
+  description: PAGE_METADATA.description,
+  keywords: PAGE_METADATA.keywords,
+  extra: {
+    mainEntity: {
+      '@type': 'ItemList',
+      name: 'Tagi bloga',
+      numberOfItems: tags.length,
+      itemListElement: tags.map((tag, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: tag.tag,
+        url: `${SITE_METADATA.url}/tags/${tag.slug}/`,
+      })),
+    },
+  },
+});
+---
+
+<PageLayout
+  breadcrumbTitle={PAGE_METADATA.title}
+  breadcrumbParents={[{ name: 'Blog 🇵🇱', url: '/blog/' }]}
+  title={PAGE_METADATA.title}
+  description={PAGE_METADATA.description}
+  lang="pl"
+>
+  <JsonLd data={structuredData} />
+  <header>
+    <h1>{PAGE_METADATA.title}</h1>
+  </header>
+  <p>Przeglądaj {tags.length} tagów i wybierz temat, który Cię interesuje.</p>
+  <ul class="tags tag-cloud" aria-label="Wszystkie tagi">
+    {
+      tags.map(tag => (
+        <li>
+          <a class="tag" href={`/tags/${tag.slug}/`}>
+            #{tag.tag} <span class="tag-count">({tag.count})</span>
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</PageLayout>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -598,6 +598,36 @@ a:focus {
   margin-bottom: var(--spacing-8);
 }
 
+/* Share row: static intent links plus a copy-link button, below the tag list. */
+.share {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-4);
+}
+
+.share-label {
+  font-family: var(--font-heading);
+  color: var(--color-text-light);
+}
+
+.share-link {
+  padding: var(--spacing-1) var(--spacing-3);
+  font-family: var(--font-heading);
+  font-size: var(--fontSize-0);
+  color: var(--color-primary);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--spacing-2);
+  background: none;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.share-link:hover {
+  border-color: var(--color-primary);
+}
+
 /* "Powiązane wpisy": shared-tag suggestions below the article body. */
 .related {
   margin-top: var(--spacing-12);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -623,6 +623,50 @@ a:focus {
   margin-bottom: var(--spacing-8);
 }
 
+/* In-post table of contents: a bordered box sitting above the article body. */
+.toc {
+  margin-bottom: var(--spacing-8);
+  padding: var(--spacing-4) var(--spacing-5);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--spacing-2);
+}
+
+.toc-title {
+  margin-top: var(--spacing-0);
+  margin-bottom: var(--spacing-2);
+  font-size: var(--fontSize-2);
+}
+
+.toc ol {
+  margin: var(--spacing-0);
+  padding-left: var(--spacing-5);
+}
+
+.toc-depth-3 {
+  margin-left: var(--spacing-4);
+}
+
+/* Heading anchors appended by rehype-autolink-headings: hidden until the heading
+   is hovered/focused so they do not clutter the reading view. */
+.heading-anchor {
+  margin-left: var(--spacing-2);
+  color: var(--color-text-light);
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+}
+
+:is(h2, h3, h4, h5, h6):hover > .heading-anchor,
+.heading-anchor:focus {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heading-anchor {
+    transition: none;
+  }
+}
+
 .posts li {
   list-style: none;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -598,6 +598,11 @@ a:focus {
   margin-bottom: var(--spacing-8);
 }
 
+/* "Powiązane wpisy": shared-tag suggestions below the article body. */
+.related {
+  margin-top: var(--spacing-12);
+}
+
 /* Previous/next post navigation: spread the two links across the row. */
 .blog-post-nav {
   /* Separate the nav from the tag list above it (the tags carry only a top


### PR DESCRIPTION
Builds on the post-migration polish with the next development batch, grouped into three themes: **discoverability/SEO**, **reader UX**, and **quality/tooling**. Each step is its own commit.

## Discoverability & SEO
- **Tag archive pages** — `/tags/` index + `/tags/<slug>/` archives. Tags were reachable only through the JS blog search (`/blog/?q=`), invisible to crawlers; now every tag has a real, indexable URL with `CollectionPage` JSON-LD. New `src/lib/tags.ts` (`slugifyTag`, `getTags`, slug-collision guard) is unit-tested; the post card is extracted into a shared `PostListItem.astro` (a `tagMode` prop preserves the blog index's progressive-enhancement search chips).
- **Dynamic Open Graph cards** — 22 of 39 posts had no `featuredImg` and fell back to the generic brand icon. `src/pages/og/[slug].png.ts` emits a branded 1200×630 title card (`~43 KB`) for them, rendered with the already-present `sharp` (`src/lib/og-image.ts`, pure `wrapText` unit-tested).
- **Sitemap enrichment** — `@astrojs/sitemap` `serialize()` adds per-post `lastmod` (`updatedDate ?? date`, read from frontmatter) and a `priority` by route type (homepage 1.0, blog 0.8, posts 0.7, tags 0.4). New `src/lib/sitemap.ts` helpers are unit-tested.

## Reader UX
- **Reading time + word count** in the post header, reusing the word count already computed for JSON-LD (`src/lib/reading-time.ts`, `src/lib/pl-plural.ts` for correct Polish plural forms — both unit-tested).
- **Heading anchors + table of contents** — `rehype-slug` gives Markdown headings ids; `rehype-autolink-headings` appends an `aria-hidden`, non-focusable hover `#`. The post renders a TOC from `render().headings` when a post has ≥3 h2/h3.
- **Related posts** by shared tags ("Powiązane wpisy"), ranked by tag overlap then date (`src/lib/related-posts.ts`, unit-tested), complementing the chronological prev/next.
- **Share buttons** — static X/LinkedIn share-intent links + a copy-link button (small inline script, no third-party widgets).

## Quality & tooling
- **JS bundle budget gate** — `helpers/ci/check-bundle-budget.mjs` fails if any page references more than 240 KB of initial `/_astro/*.js` (heaviest today ~200 KB; Mermaid's runtime chunks are correctly excluded). Wired into `build-contract`.
- **E2E coverage** for blog pagination (`/blog/2/`, prev/next) and the `/resume → /bio/` redirect; the a11y scan now also covers `/tags/`.
- **Lighthouse performance gate** — promoted from advisory to error (`minScore 0.8`) and stabilised by running each URL three times and asserting on the median.

## Verification
- `type:check`, `lint:check`, `lint:css`, `format:check`, `a11y:contrast` — clean.
- Unit tests: **62 passing** across **12 files** (6 new lib modules added with tests).
- `pnpm build` succeeds; all `dist/` contracts pass (build-output, url-parity, build-output regression incl. tag archives, seo-meta, seo-lengths, image-budget, bundle-budget). Internal link check clean (1119 links).
- **Not run locally:** the Playwright e2e and Lighthouse jobs — the sandbox can't download a browser. The specs/config are validated against the built HTML and will run in CI. The Lighthouse performance gate is enforced for the first time here, so that job is the one to watch on this PR.