### PR TITLE
fix(blog): tidy blog top layout, breadcrumbs and separators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Potrzebne przy modyfikacji `[...slug].astro`, `content.config.ts`, RSS (`rss.xml
 - **Komponenty:** statyczne pisz jako `.astro`; React (`.tsx`) tylko dla realnej interaktywności, jawnie hydratowany dyrektywą `client:*` (np. `client:load`, `client:visible`). Wyspy React: typ `FC`, nazwy PascalCase, importy hooków imienne.
 - **Pliki:** komponenty `.astro` PascalCase; skrypty/dane kebab-case. **Stałe:** UPPER_SNAKE_CASE.
 - **Style:** czyste CSS z custom properties (design tokens), bez preprocesorów; lintowane przez **Stylelint** (`stylelint-config-standard`, `normalize.css` wykluczony). Montserrat (nagłówki), Merriweather (tekst). Dark mode automatyczny przez `prefers-color-scheme` (bez przełącznika JS).
+- **Mobile-first:** reguły bazowe pisz pod najmniejszy ekran; większe widoki dodawaj wyłącznie przez `min-width` media queries (skala `sm = 30rem`, `md = 48rem` — patrz komentarz w `main.css`). Nie używaj `max-width` do cofania stylów desktopowych. Układy mają się zawijać (`flex-wrap`), a nie obcinać/skrolować w poziomie na wąskich ekranach. Separatory inline (np. RSS/tagi, meta wpisu, okruszki) trzymaj spójne z menu — kropka `•` (`.separator` lub `li::after`), nie `|`.
 - **Dane strukturalne:** JSON-LD przez `JsonLd.astro` (zwykłe obiekty, bez schema-dts).
 - **Prettier:** single quotes, średniki, 2 spacje, `printWidth: 120`, `arrowParens: avoid`, plugin `prettier-plugin-astro`.
 - **Komentarze:** tylko po angielsku i tylko te realnie wartościowe — wyjaśniaj „dlaczego”, a nie to, co kod już mówi sam.

--- a/helpers/ci/check-astro-build-output.mjs
+++ b/helpers/ci/check-astro-build-output.mjs
@@ -11,7 +11,7 @@
  *   - the memoization post's interactive demo hydrates (client:visible island)
  *   - blog-list thumbnails render at a bounded (600px) size, not full-res
  *   - content list markers stay outside (not dropped onto their own line / clipped)
- *   - breadcrumbs truncate on one line (no horizontal-scroll fallback)
+ *   - breadcrumbs wrap onto multiple lines on mobile (no truncation / scroll)
  *   - the /files/ page lists presentations (static/files is read from disk)
  *   - the /files/ cmd/ctrl+shift+. hidden-variant toggle ships and is wired up
  *   - the /setup/ Mermaid diagram cannot push page-level horizontal scroll
@@ -97,11 +97,14 @@ async function checkBreadcrumbs(css) {
     fail('breadcrumbs ol rule not found in bundled CSS');
     return;
   }
-  if (!/flex-wrap:\s*nowrap/.test(m[1])) {
-    fail('breadcrumbs no longer nowrap (wrapping regressed)');
+  // Mobile-first contract: the trail wraps onto multiple lines on narrow
+  // screens (left-aligned), never truncating crumbs or introducing horizontal
+  // scroll.
+  if (!/flex-wrap:\s*wrap/.test(m[1])) {
+    fail('breadcrumbs no longer wrap (would truncate/overflow on mobile)');
   }
   if (/overflow-x/.test(m[1])) {
-    fail('breadcrumbs reintroduced horizontal scroll (should be ellipsis only)');
+    fail('breadcrumbs reintroduced horizontal scroll (should wrap instead)');
   }
 }
 

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -82,7 +82,7 @@ const structuredData = {
       <hr />
       <nav class="breadcrumbs" aria-label="Breadcrumb">
         <ol>
-          {crumbs.map((item, index) => (
+          {crumbs.map(item => (
             <li class={item.isActive ? 'active' : ''}>
               {item.isActive ? (
                 <span aria-current="page" title={item.title}>
@@ -92,11 +92,6 @@ const structuredData = {
                 <a href={item.url} title={item.title}>
                   {item.name}
                 </a>
-              )}
-              {index < crumbs.length - 1 && (
-                <span class="separator" aria-hidden="true">
-                  {' / '}
-                </span>
               )}
             </li>
           ))}

--- a/src/components/PostListItem.astro
+++ b/src/components/PostListItem.astro
@@ -36,7 +36,7 @@ const dateFormatted = formatPolishDate(post.data.date);
       </h2>
       <small>
         <span>{dateFormatted}</span>
-        &nbsp;|&nbsp;
+        <span class="separator" aria-hidden="true">•</span>
         <span>
           <a href="/bio/">{author.name}</a>
         </span>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -130,10 +130,14 @@ const structuredData = {
       <h1>{title}</h1>
       <small>
         <span>{dateFormatted}</span>
-        &nbsp;|&nbsp;
+        <span class="separator" aria-hidden="true">•</span>
         <span><a href="/bio/">{SITE_METADATA.author.name}</a></span>
-        &nbsp;|&nbsp;
-        <span>{readingTime} min czytania &middot; {words} {plPlural(words, ['słowo', 'słowa', 'słów'])}</span>
+        <span class="separator" aria-hidden="true">•</span>
+        <span
+          >{readingTime} min czytania <span class="separator" aria-hidden="true">•</span>
+          {words}
+          {plPlural(words, ['słowo', 'słowa', 'słów'])}</span
+        >
       </small>
     </header>
     {

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -99,9 +99,11 @@ const structuredData = {
     <h1>{PAGE_METADATA.title}</h1>
   </header>
   <div class="rss">
-    <Image src={rssIcon} alt="Ikona RSS" width={20} height={20} layout="fixed" />
-    <a href="/rss.xml" type="application/rss+xml">Subskrybuj kanał RSS</a>
-    &nbsp;|&nbsp;
+    <span class="rss-feed">
+      <Image src={rssIcon} alt="Ikona RSS" width={20} height={20} layout="fixed" />
+      <a href="/rss.xml" type="application/rss+xml">Subskrybuj kanał RSS</a>
+    </span>
+    <span class="separator" aria-hidden="true">•</span>
     <a href="/tags/">Przeglądaj tagi</a>
   </div>
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -413,6 +413,12 @@ a:focus {
   margin-top: var(--spacing-8) !important;
 }
 
+/* The first card has no divider above it, so it does not need the full
+   inter-post gap — keep it close to the search box / page header. */
+.posts > li:first-child .post-list-item {
+  margin-top: var(--spacing-4) !important;
+}
+
 .post-list-item p {
   margin-bottom: var(--spacing-0);
 }
@@ -651,7 +657,23 @@ a:focus {
 
 .rss {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.rss-feed {
+  display: inline-flex;
+  align-items: center;
   gap: var(--spacing-2);
+}
+
+/* Shared inline bullet separator, matching the main menu (.menu li::after).
+   Carries its own margin so it spaces consistently in both inline meta rows
+   (date • author • reading time) and the flex RSS/tags row. */
+.separator {
+  margin: 0 var(--spacing-2);
+  color: var(--color-text-light);
+  user-select: none;
 }
 
 .gatsby-highlight {
@@ -782,7 +804,11 @@ a:focus {
 
 .blog-search {
   display: block;
-  margin: var(--spacing-6) var(--spacing-0);
+
+  /* Bottom margin trimmed: the live-region status below the input already
+     reserves a line, and the first post card carries its own top margin, so a
+     full margin here stacked into an oversized gap under the search box. */
+  margin: var(--spacing-6) var(--spacing-0) var(--spacing-0);
 }
 
 .blog-search label {
@@ -814,7 +840,7 @@ a:focus {
 .blog-search-status {
   font-size: var(--fontSize-0);
   color: var(--color-text-light);
-  margin: var(--spacing-2) var(--spacing-0) var(--spacing-0);
+  margin: var(--spacing-1) var(--spacing-0) var(--spacing-0);
   min-height: 1.5em;
 }
 
@@ -942,14 +968,17 @@ a:focus {
   color: var(--color-text-light);
 }
 
+/* Mobile-first: the trail wraps onto multiple lines on narrow screens (no
+   truncation, no horizontal scroll) and stays left-aligned. Crumbs keep their
+   natural width — none grow to fill the row, so the active crumb sits next to
+   its parent instead of being pushed to the centre. */
 .breadcrumbs ol {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
   margin: var(--spacing-0);
   padding: var(--spacing-0);
   list-style: none;
-  gap: var(--spacing-1);
 }
 
 .breadcrumbs li {
@@ -957,22 +986,21 @@ a:focus {
   align-items: center;
   margin: var(--spacing-0);
   padding: var(--spacing-0);
-  max-width: 100%;
-}
-
-.breadcrumbs li:first-child {
-  flex-shrink: 0;
-}
-
-.breadcrumbs li:not(:first-child) {
   min-width: 0;
-  flex: 1 1 auto;
+}
+
+/* Bullet separator, matching the main menu (see .menu li::after). */
+.breadcrumbs li:not(:last-child)::after {
+  content: '•';
+  margin: 0 var(--spacing-2);
+  color: var(--color-text-light);
+  user-select: none;
 }
 
 .breadcrumbs a,
 .breadcrumbs span {
   display: inline-block;
-  padding: var(--spacing-1) var(--spacing-2);
+  padding: 0 var(--spacing-1);
   border-radius: var(--spacing-1);
   text-decoration: none;
   transition:
@@ -980,10 +1008,7 @@ a:focus {
     color 0.2s ease;
   overflow-wrap: break-word;
   hyphens: auto;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0;
 }
 
 .breadcrumbs a {
@@ -999,15 +1024,6 @@ a:focus {
 .breadcrumbs li.active span {
   color: var(--color-text);
   font-weight: var(--fontWeight-bold);
-  background-color: var(--color-accent);
-}
-
-.breadcrumbs .separator {
-  margin: 0 var(--spacing-1);
-  color: var(--color-text-light);
-  font-weight: var(--fontWeight-normal);
-  flex-shrink: 0;
-  user-select: none;
 }
 
 /* Accessibility improvements */


### PR DESCRIPTION
- Wrap breadcrumbs mobile-first instead of truncating crumbs on one line;
  keep the trail left-aligned and drop the oversized active-crumb box/padding
- Replace ad-hoc "|" separators (RSS/tags row, post meta) with the menu-style
  bullet for a consistent look site-wide
- Trim the gap under the blog search box and the first post card's top margin
- Update the breadcrumb build-output contract to assert wrapping, not nowrap
- Document the mobile-first CSS convention in CLAUDE.md