### PR TITLE
style: unify pill control sizing and radius across tags, pagination and breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,11 +1,11 @@
 ---
 import { SITE_METADATA } from '../data/site-metadata';
 import JsonLd from './JsonLd.astro';
+import { buildCrumbs } from '../lib/breadcrumbs';
 import type { NavLink } from '../types';
 
-// Port of src/components/breadcrumbs.tsx. Builds the trail from the current
-// pathname, mapping known menu segments to their labels and using the page's
-// custom title for the active (last) crumb.
+// Builds the trail from the current pathname, mapping known menu segments to
+// their labels and using the page's custom title for the active (last) crumb.
 interface Props {
   customTitle: string;
   // Extra ancestor crumbs inserted between Home and the path-derived trail.
@@ -16,48 +16,13 @@ interface Props {
 
 const { customTitle, parents = [] } = Astro.props;
 const siteUrl = `${SITE_METADATA.url}/`;
-const menu = SITE_METADATA.menu;
-const pathname = Astro.url.pathname;
 
-type Crumb = { name: string; title: string; url: string; isActive: boolean };
-
-function buildCrumbs(): Crumb[] {
-  const segments = pathname.split('/').filter(Boolean);
-  const crumbs: Crumb[] = [{ name: '🏠', title: 'Home', url: '/', isActive: pathname === '/' }];
-
-  if (pathname === '/') {
-    return crumbs;
-  }
-
-  // Injected ancestors (e.g. Blog for a post) come right after Home.
-  for (const parent of parents) {
-    crumbs.push({ name: parent.name, title: parent.name, url: parent.url, isActive: false });
-  }
-
-  const pathMap = menu.reduce<Record<string, string>>((acc, item) => {
-    acc[item.url.replace(/\//g, '')] = item.name;
-    return acc;
-  }, {});
-
-  let currentPath = '';
-  segments.forEach((segment, index) => {
-    currentPath += '/' + segment;
-    // Trailing slash keeps crumb hrefs canonical under trailingSlash: 'always',
-    // so relative links inside nested pages resolve correctly.
-    const url = `${currentPath}/`;
-    const isLast = index === segments.length - 1;
-    if (isLast) {
-      crumbs.push({ name: customTitle, title: customTitle, url, isActive: true });
-    } else {
-      const name = pathMap[segment] || segment.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-      crumbs.push({ name, title: name, url, isActive: false });
-    }
-  });
-
-  return crumbs;
-}
-
-const crumbs = buildCrumbs();
+const crumbs = buildCrumbs({
+  pathname: Astro.url.pathname,
+  customTitle,
+  menu: SITE_METADATA.menu,
+  parents,
+});
 const show = crumbs.length > 1;
 
 const structuredData = {

--- a/src/components/PostListItem.astro
+++ b/src/components/PostListItem.astro
@@ -6,6 +6,8 @@ import { excerpt } from '../lib/excerpt';
 import { inlineMarkdown } from '../lib/inline-markdown';
 import { formatPolishDate } from '../lib/date';
 import { slugifyTag } from '../lib/tags';
+import { countWords, readingTimeMinutes } from '../lib/reading-time';
+import { plPlural } from '../lib/pl-plural';
 
 // Shared blog post card (one <li> in a .posts list). Used by the blog index, the
 // tag archives and the related-posts section so the markup stays in one place.
@@ -20,6 +22,11 @@ const author = SITE_METADATA.author;
 const description = post.data.description || excerpt(post.body ?? '');
 const descriptionHtml = inlineMarkdown(description);
 const dateFormatted = formatPolishDate(post.data.date);
+
+// Reading-time and word-count meta, matching the post header so listings, tag
+// archives and the related section read consistently with the article itself.
+const words = countWords(post.body);
+const readingTime = readingTimeMinutes(words);
 ---
 
 <li>
@@ -33,6 +40,12 @@ const dateFormatted = formatPolishDate(post.data.date);
         <span class="separator" aria-hidden="true">•</span>
         <span>
           <a href="/bio/">{author.name}</a>
+        </span>
+        <span class="separator" aria-hidden="true">•</span>
+        <span>
+          {readingTime} min czytania <span class="separator" aria-hidden="true">•</span>
+          {words}
+          {plPlural(words, ['słowo', 'słowa', 'słów'])}
         </span>
       </small>
     </header>

--- a/src/lib/breadcrumbs.test.ts
+++ b/src/lib/breadcrumbs.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildCrumbs } from './breadcrumbs';
+import type { NavLink } from '../types';
+
+const MENU: NavLink[] = [
+  { name: 'Home', url: '/' },
+  { name: 'About', url: '/bio/' },
+  { name: 'Blog 🇵🇱', url: '/blog/' },
+  { name: 'Contact', url: '/contact/' },
+];
+
+const names = (pathname: string, customTitle: string, parents?: NavLink[]) =>
+  buildCrumbs({ pathname, customTitle, menu: MENU, parents }).map(c => c.name);
+
+describe('buildCrumbs', () => {
+  it('returns only the active Home crumb on the root path', () => {
+    const crumbs = buildCrumbs({ pathname: '/', customTitle: 'Home', menu: MENU });
+    expect(crumbs).toHaveLength(1);
+    expect(crumbs[0]).toMatchObject({ name: '🏠', url: '/', isActive: true });
+  });
+
+  it('labels a top-level page from the menu and marks it active', () => {
+    const crumbs = buildCrumbs({ pathname: '/blog/', customTitle: 'Blog 🇵🇱', menu: MENU });
+    expect(crumbs.map(c => c.name)).toEqual(['🏠', 'Blog 🇵🇱']);
+    expect(crumbs.at(-1)).toMatchObject({ isActive: true, url: '/blog/' });
+    expect(crumbs[0].isActive).toBe(false);
+  });
+
+  it('injects a parent that is not part of the path (post under Blog)', () => {
+    expect(names('/od-tablicy-do-mapy/', 'Od tablicy do mapy', [{ name: 'Blog 🇵🇱', url: '/blog/' }])).toEqual([
+      '🏠',
+      'Blog 🇵🇱',
+      'Od tablicy do mapy',
+    ]);
+  });
+
+  it('does not duplicate a parent whose URL matches a path segment (tag detail)', () => {
+    // Regression: /tags/devops/ used to render both the injected "Tagi" parent
+    // and a path-derived "Tags" crumb. The parent must label the /tags/ segment
+    // instead of being added twice.
+    const crumbs = buildCrumbs({
+      pathname: '/tags/devops/',
+      customTitle: 'Tag: devops',
+      menu: MENU,
+      parents: [
+        { name: 'Blog 🇵🇱', url: '/blog/' },
+        { name: 'Tagi', url: '/tags/' },
+      ],
+    });
+    expect(crumbs.map(c => c.name)).toEqual(['🏠', 'Blog 🇵🇱', 'Tagi', 'Tag: devops']);
+    // The middle "Tagi" crumb keeps the canonical /tags/ href.
+    expect(crumbs[2]).toMatchObject({ url: '/tags/', isActive: false });
+    expect(crumbs.at(-1)).toMatchObject({ url: '/tags/devops/', isActive: true });
+  });
+
+  it('handles the tags index without duplicating the path segment', () => {
+    expect(names('/tags/', 'Tagi', [{ name: 'Blog 🇵🇱', url: '/blog/' }])).toEqual(['🏠', 'Blog 🇵🇱', 'Tagi']);
+  });
+
+  it('title-cases an unknown intermediate segment with hyphens', () => {
+    expect(names('/foo-bar/baz/', 'Baz')).toEqual(['🏠', 'Foo Bar', 'Baz']);
+  });
+
+  it('treats parent URLs with or without a trailing slash as equal', () => {
+    expect(names('/tags/devops/', 'Tag: devops', [{ name: 'Tagi', url: '/tags' }])).toEqual([
+      '🏠',
+      'Tagi',
+      'Tag: devops',
+    ]);
+  });
+});

--- a/src/lib/breadcrumbs.ts
+++ b/src/lib/breadcrumbs.ts
@@ -1,0 +1,77 @@
+import type { NavLink } from '../types';
+
+export type Crumb = { name: string; title: string; url: string; isActive: boolean };
+
+export interface BuildCrumbsOptions {
+  // Current page pathname, e.g. '/tags/devops/'.
+  pathname: string;
+  // Label for the active (last) crumb — the page's own title.
+  customTitle: string;
+  // Site menu, used to map a path segment to its human label (e.g. blog → Blog 🇵🇱).
+  menu: NavLink[];
+  // Extra ancestor crumbs (e.g. Blog for a post at /slug/). A parent whose URL
+  // coincides with a real path segment supplies that segment's label instead of
+  // being added as a separate, duplicate crumb.
+  parents?: NavLink[];
+}
+
+// Strip the trailing slash so '/tags/' and '/tags' compare equal. The root '/'
+// is left intact.
+const normalizeUrl = (url: string): string => (url.length > 1 ? url.replace(/\/+$/, '') : url);
+
+// Fallback label for a path segment with no menu/parent match: 'foo-bar' → 'Foo Bar'.
+const titleCase = (segment: string): string => segment.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+
+// Builds the breadcrumb trail from the current pathname. Known menu segments and
+// injected parents provide friendly labels; the active page uses customTitle.
+export function buildCrumbs({ pathname, customTitle, menu, parents = [] }: BuildCrumbsOptions): Crumb[] {
+  const crumbs: Crumb[] = [{ name: '🏠', title: 'Home', url: '/', isActive: pathname === '/' }];
+
+  if (pathname === '/') {
+    return crumbs;
+  }
+
+  const segments = pathname.split('/').filter(Boolean);
+
+  // Menu labels keyed by their single path segment, e.g. { blog: 'Blog 🇵🇱' }.
+  const pathMap = menu.reduce<Record<string, string>>((acc, item) => {
+    acc[item.url.replace(/\//g, '')] = item.name;
+    return acc;
+  }, {});
+
+  // URLs that actually appear in the current path. A parent matching one of these
+  // labels its segment rather than adding a separate crumb — otherwise
+  // /tags/devops/ would render both the injected "Tagi" and the path-derived "Tags".
+  const pathUrls = new Set<string>();
+  let walked = '';
+  for (const segment of segments) {
+    walked += '/' + segment;
+    pathUrls.add(normalizeUrl(walked + '/'));
+  }
+
+  const parentByUrl = new Map(parents.map(parent => [normalizeUrl(parent.url), parent]));
+
+  // Inject only the parents that are NOT part of the path (e.g. Blog for a post
+  // at /slug/), right after Home and in order.
+  for (const parent of parents) {
+    if (!pathUrls.has(normalizeUrl(parent.url))) {
+      crumbs.push({ name: parent.name, title: parent.name, url: parent.url, isActive: false });
+    }
+  }
+
+  let currentPath = '';
+  segments.forEach((segment, index) => {
+    currentPath += '/' + segment;
+    // Trailing slash keeps crumb hrefs canonical under trailingSlash: 'always'.
+    const url = `${currentPath}/`;
+    const isLast = index === segments.length - 1;
+    if (isLast) {
+      crumbs.push({ name: customTitle, title: customTitle, url, isActive: true });
+    } else {
+      const name = parentByUrl.get(normalizeUrl(url))?.name || pathMap[segment] || titleCase(segment);
+      crumbs.push({ name, title: name, url, isActive: false });
+    }
+  });
+
+  return crumbs;
+}

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -174,6 +174,7 @@ const structuredData = {
 
 <script>
   import { slugifyTag } from '../../lib/slugify-tag';
+  import { SITE_METADATA } from '../../data/site-metadata';
 
   // Progressive-enhancement search across ALL posts (not just the current page).
   // The index is fetched once, lazily, on first interaction.
@@ -183,6 +184,9 @@ const structuredData = {
     descriptionHtml: string;
     tags: string[];
     dateFormatted: string;
+    readingTime: number;
+    words: number;
+    wordsLabel: string;
     url: string;
     img?: { src: string; alt: string };
   };
@@ -234,8 +238,30 @@ const structuredData = {
         titleLink.href = item.url;
         titleLink.textContent = item.title;
         h2.appendChild(titleLink);
+        // Mirror PostListItem's meta row: date • author • reading time • words,
+        // bullet-separated with the shared .separator span.
+        const separator = () => {
+          const span = document.createElement('span');
+          span.className = 'separator';
+          span.setAttribute('aria-hidden', 'true');
+          span.textContent = '•';
+          return span;
+        };
+
+        const dateSpan = document.createElement('span');
+        dateSpan.textContent = item.dateFormatted;
+
+        const authorSpan = document.createElement('span');
+        const authorLink = document.createElement('a');
+        authorLink.href = '/bio/';
+        authorLink.textContent = SITE_METADATA.author.name;
+        authorSpan.appendChild(authorLink);
+
+        const metaSpan = document.createElement('span');
+        metaSpan.append(`${item.readingTime} min czytania `, separator(), ` ${item.words} ${item.wordsLabel}`);
+
         const small = document.createElement('small');
-        small.textContent = item.dateFormatted;
+        small.append(dateSpan, separator(), authorSpan, separator(), metaSpan);
         header.append(h2, small);
 
         const section = document.createElement('section');

--- a/src/pages/blog/search.json.ts
+++ b/src/pages/blog/search.json.ts
@@ -3,6 +3,8 @@ import { getBlogPosts } from '../../lib/blog';
 import { excerpt } from '../../lib/excerpt';
 import { inlineMarkdown } from '../../lib/inline-markdown';
 import { formatPolishDate } from '../../lib/date';
+import { countWords, readingTimeMinutes } from '../../lib/reading-time';
+import { plPlural } from '../../lib/pl-plural';
 
 // Static search index consumed by the client-side blog search. Covers every
 // listed post so search spans the whole archive, not just the current page.
@@ -23,12 +25,21 @@ export async function GET() {
       // rendered inline Markdown for display.
       const plainDescription = description || excerpt(post.body ?? '');
 
+      // Reading-time/word-count meta so search result cards match the static
+      // listing (PostListItem). The plural form is resolved here to keep the
+      // Polish pluralisation logic on the server.
+      const words = countWords(post.body);
+      const readingTime = readingTimeMinutes(words);
+
       return {
         title,
         description: plainDescription,
         descriptionHtml: inlineMarkdown(plainDescription),
         tags,
         dateFormatted: formatPolishDate(date),
+        readingTime,
+        words,
+        wordsLabel: plPlural(words, ['słowo', 'słowa', 'słów']),
         url: `/${post.id}/`,
         ...(img ? { img } : {}),
       };

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -65,5 +65,4 @@ const structuredData = createPageSchema({
   <ol class="posts">
     {tag.posts.map(post => <PostListItem post={post} />)}
   </ol>
-  <p><a href="/tags/">← Wszystkie tagi</a></p>
 </PageLayout>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -236,6 +236,13 @@ table {
   margin-bottom: var(--spacing-8);
   font-size: var(--fontSize-0);
   white-space: nowrap;
+
+  /* Match the rounded corners of the other media boxes (images, code, TOC,
+     figures). The block-level scroll container (overflow-x: auto) clips the
+     header/zebra cell backgrounds to the radius, and the border traces the
+     rounded edge. */
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-pill);
 }
 
 pre {
@@ -300,10 +307,15 @@ main section .tags {
   padding-left: var(--spacing-0);
 }
 
+/* The accent bar sits at the content's left edge. Earlier this pulled the
+   blockquote left by --spacing-6 on every screen, but on mobile the wrapper
+   padding is only --spacing-4, so the bar fell outside the wrapper's
+   overflow-x: hidden and was clipped. Keep the bar flush with the content edge
+   at every breakpoint instead. */
 blockquote {
   color: var(--color-text-light);
-  margin-left: calc(-1 * var(--spacing-6));
-  margin-right: var(--spacing-8);
+  margin-left: var(--spacing-0);
+  margin-right: var(--spacing-0);
   padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-6);
   border-left: var(--spacing-1) solid var(--color-primary);
   font-size: var(--fontSize-2);
@@ -335,6 +347,13 @@ table th {
 
 table tr:nth-child(even) {
   background-color: var(--color-accent);
+}
+
+/* The outer rounded border already closes the table, so drop the last row's
+   cell borders to avoid a straight line doubling up inside the rounded corners. */
+table tr:last-child th,
+table tr:last-child td {
+  border-bottom: 0;
 }
 
 /* Column width hints applied to <col> elements so width values stay out of
@@ -502,8 +521,10 @@ a:focus {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: var(--spacing-10);
-  margin-bottom: var(--spacing-10);
+
+  /* Uniform gap around the page rules: the bio and the footer below both use
+     --spacing-6 so the chrome above the footer is evenly, tightly spaced. */
+  margin-block: var(--spacing-6);
 }
 
 .bio .avatar {
@@ -620,17 +641,26 @@ a:focus {
   font-family: var(--font-heading);
 }
 
-.blog-post .gatsby-image-wrapper:not(footer .gatsby-image-wrapper) {
+/* The featured image sits between the header and the TOC/body. <picture> is
+   inline by default, so make it a block and give it the canonical block gap
+   (--spacing-8) shared by paragraphs, lists, tables, code and the TOC — without
+   it the image butts straight against the TOC. */
+.blog-post > picture {
+  display: block;
   margin-bottom: var(--spacing-8);
 }
 
-/* Share row: static intent links plus a copy-link button, below the tag list. */
+/* Share row: static intent links plus a copy-link button, below the tag list.
+   A top rule (matching the site's <hr>: 1px, --color-accent) sets it apart from
+   the tags above. */
 .share {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-2);
-  margin-top: var(--spacing-4);
+  margin-top: var(--spacing-8);
+  padding-top: var(--spacing-6);
+  border-top: 1px solid var(--color-accent);
 }
 
 .share-label {
@@ -654,16 +684,14 @@ a:focus {
   border-color: var(--color-primary);
 }
 
-/* "Powiązane wpisy": shared-tag suggestions below the article body. */
-.related {
-  margin-top: var(--spacing-12);
-}
-
-/* Previous/next post navigation: spread the two links across the row. */
+/* Post-footer sections (related posts, prev/next nav) are each set off from the
+   content above by the shared rule — 1px, --color-accent, matching the site's
+   <hr> — so the end of an article reads as distinct blocks. */
+.related,
 .blog-post-nav {
-  /* Separate the nav from the tag list above it (the tags carry only a top
-     margin, so without this they sit flush against the prev/next links). */
   margin-top: var(--spacing-8);
+  padding-top: var(--spacing-8);
+  border-top: 1px solid var(--color-accent);
 }
 
 .blog-post-nav ul {
@@ -992,14 +1020,8 @@ a:focus {
 
 /* Media queries */
 
-/* From the md breakpoint up, prose lists pull their markers into the gutter and
-   blockquotes hang into the left margin. */
+/* From the md breakpoint up, prose lists pull their markers into the gutter. */
 @media (width >= 48rem) {
-  blockquote {
-    margin-left: calc(-1 * var(--spacing-6));
-    padding-left: var(--spacing-6);
-  }
-
   ul,
   ol {
     list-style-position: outside;
@@ -1175,9 +1197,11 @@ a:focus {
   justify-content: space-between;
   flex-wrap: wrap;
 
-  /* Match the breathing room the bio has around its dividers so the footer is
-     not flush against the rule above it. */
-  margin-top: var(--spacing-8);
+  /* Match the bio's --spacing-6 gap so the footer sits a uniform distance below
+     the rule above it. Font size matches the rest of the page chrome
+     (breadcrumbs, bio) so the secondary text is uniform. */
+  margin-top: var(--spacing-6);
+  font-size: var(--fontSize-0);
 }
 
 .footer-metadata a {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -63,6 +63,18 @@
 
   /* Text rendered on top of --color-primary (e.g. table headers). */
   --color-on-primary: #fff;
+
+  /* Corner radii (semantic aliases over the spacing scale) so the whole
+     interactive family rounds consistently:
+       --radius-control — inline links/crumbs with a subtle hover surface
+       --radius-pill    — pill controls: tags, pagination, share links */
+  --radius-control: var(--spacing-1);
+  --radius-pill: var(--spacing-2);
+
+  /* Minimum tap target for compact icon/numeric controls (pagination arrows
+     and page numbers). 2.25rem = 36px — comfortably above the WCAG AA 24px
+     floor while staying proportional to the tag chips beside it. */
+  --size-control: 2.25rem;
 }
 
 /* Dark theme: pure CSS, driven by the OS setting. Only the color tokens are
@@ -632,7 +644,7 @@ a:focus {
   font-size: var(--fontSize-0);
   color: var(--color-primary);
   border: 1px solid var(--color-accent);
-  border-radius: var(--spacing-2);
+  border-radius: var(--radius-pill);
   background: none;
   cursor: pointer;
   text-decoration: none;
@@ -898,7 +910,7 @@ a:focus {
   font-size: var(--fontSize-0);
   line-height: 1.2;
   padding: var(--spacing-1) var(--spacing-3);
-  border-radius: var(--spacing-2);
+  border-radius: var(--radius-pill);
   background-color: var(--color-accent);
   color: var(--color-primary);
   text-decoration: none;
@@ -946,10 +958,10 @@ a:focus {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 2.75rem;
-  min-height: 2.75rem;
-  padding: var(--spacing-1) var(--spacing-2);
-  border-radius: var(--spacing-1);
+  min-width: var(--size-control);
+  min-height: var(--size-control);
+  padding: var(--spacing-1) var(--spacing-3);
+  border-radius: var(--radius-pill);
   text-decoration: none;
   font-family: var(--font-heading);
   font-size: var(--fontSize-0);
@@ -1034,7 +1046,7 @@ a:focus {
 .breadcrumbs span {
   display: inline-block;
   padding: 0 var(--spacing-1);
-  border-radius: var(--spacing-1);
+  border-radius: var(--radius-control);
   text-decoration: none;
   transition:
     background-color 0.2s ease,


### PR DESCRIPTION
Pagination buttons rendered as 44px squares with a tighter radius than the
tag chips and share links beside them, so they looked oversized and visually
detached. Introduce semantic radius tokens (--radius-control, --radius-pill)
and a shared --size-control tap target, then align the interactive family on
one shape: tags, pagination and share links share --radius-pill, and
pagination shrinks from 2.75rem to 2.25rem (still above the WCAG AA 24px
target floor) with chip-matching horizontal padding.