### PR TITLE
fix: stop tag chips inheriting the post-card divider line

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -908,7 +908,10 @@ a:focus {
   list-style: none;
 }
 
-.posts li + li {
+/* Direct child only: a divider between post cards. Without the `>` the rule
+   also leaks onto the tag chips (.tags li), drawing a stray line above every
+   tag after the first. */
+.posts > li + li {
   border-top: 1px solid var(--color-accent);
 }
 


### PR DESCRIPTION
## Problem

In post listings (blog index, tag archives, and the "Powiązane wpisy" related-posts section), a stray horizontal line appeared above every tag chip after the first one.

## Cause

The divider between post cards was defined with an unscoped descendant selector:

```css
.posts li + li {
  border-top: 1px solid var(--color-accent);
}
```

Because `li + li` matches **any** adjacent `<li>` inside `.posts`, it also matched the tag chips (`.tags li`) nested within each `PostListItem`, drawing the `border-top` above each tag after the first.

## Fix

Scope the rule to direct children only, so it applies to post cards but not the nested tag list:

```css
.posts > li + li {
  border-top: 1px solid var(--color-accent);
}
```

Dividers between post cards are unchanged.

## Verification

- `pnpm lint:css` — pass
- `pnpm format:check` — pass
- `pnpm type:check` — 0 errors