### PR TITLE
refactor: extract share section into Share and ShareLink components

### DIFF
--- a/src/components/Share.astro
+++ b/src/components/Share.astro
@@ -1,0 +1,42 @@
+---
+import { SITE_METADATA } from '../data/site-metadata';
+import ShareLink from './ShareLink.astro';
+
+interface Props {
+  // Used as the pre-filled text for the X intent link.
+  title: string;
+}
+
+const { title } = Astro.props;
+
+// Share targets: static intent URLs (no third-party widgets/scripts) plus a
+// copy-link button wired up by the inline script below.
+const shareUrl = new URL(Astro.url.pathname, SITE_METADATA.url).href;
+const shareOnX = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(shareUrl)}`;
+const shareOnLinkedIn = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+---
+
+<div class="share">
+  <span class="share-label">Udostępnij:</span>
+  <ShareLink href={shareOnX}>X</ShareLink>
+  <ShareLink href={shareOnLinkedIn}>LinkedIn</ShareLink>
+  <ShareLink shareUrl={shareUrl}>Kopiuj link</ShareLink>
+</div>
+
+<script>
+  // Copy-link button: writes the post URL to the clipboard with brief feedback.
+  // Progressive enhancement — the share intent links work without it.
+  const button = document.querySelector<HTMLButtonElement>('.share-copy');
+  if (button) {
+    const original = button.textContent;
+    button.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(button.dataset.shareUrl ?? location.href);
+        button.textContent = 'Skopiowano!';
+        window.setTimeout(() => (button.textContent = original), 2000);
+      } catch {
+        // Clipboard API unavailable (e.g. insecure context); leave the label.
+      }
+    });
+  }
+</script>

--- a/src/components/ShareLink.astro
+++ b/src/components/ShareLink.astro
@@ -1,0 +1,23 @@
+---
+// A single share control. Renders an outbound intent link when given `href`,
+// or the copy-link button (wired up by Share.astro's script) when given
+// `shareUrl` instead. Both variants share the .share-link pill styling.
+interface Props {
+  href?: string;
+  shareUrl?: string;
+}
+
+const { href, shareUrl } = Astro.props;
+---
+
+{
+  href ? (
+    <a class="share-link" href={href} target="_blank" rel="noopener noreferrer nofollow">
+      <slot />
+    </a>
+  ) : (
+    <button class="share-link share-copy" type="button" data-share-url={shareUrl}>
+      <slot />
+    </button>
+  )
+}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,6 +4,7 @@ import { Picture, getImage } from 'astro:assets';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
 import PostListItem from '../components/PostListItem.astro';
+import Share from '../components/Share.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
 import { formatPolishDate, toISODate } from '../lib/date';
@@ -80,12 +81,6 @@ const ogImageHeight = featuredImg
 const words = countWords(post.body);
 const wordCount = words || undefined;
 const readingTime = readingTimeMinutes(words);
-
-// Share targets: static intent URLs (no third-party widgets/scripts) plus a
-// copy-link button wired up by the inline script below.
-const shareUrl = new URL(Astro.url.pathname, SITE_METADATA.url).href;
-const shareOnX = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(shareUrl)}`;
-const shareOnLinkedIn = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -188,12 +183,7 @@ const structuredData = {
         ))
       }
     </ul>
-    <div class="share">
-      <span class="share-label">Udostępnij:</span>
-      <a class="share-link" href={shareOnX} target="_blank" rel="noopener noreferrer nofollow">X</a>
-      <a class="share-link" href={shareOnLinkedIn} target="_blank" rel="noopener noreferrer nofollow">LinkedIn</a>
-      <button class="share-link share-copy" type="button" data-share-url={shareUrl}>Kopiuj link</button>
-    </div>
+    <Share title={title} />
   </article>
 
   {
@@ -235,21 +225,3 @@ const structuredData = {
     )
   }
 </PageLayout>
-
-<script>
-  // Copy-link button: writes the post URL to the clipboard with brief feedback.
-  // Progressive enhancement — the share intent links work without it.
-  const button = document.querySelector<HTMLButtonElement>('.share-copy');
-  if (button) {
-    const original = button.textContent;
-    button.addEventListener('click', async () => {
-      try {
-        await navigator.clipboard.writeText(button.dataset.shareUrl ?? location.href);
-        button.textContent = 'Skopiowano!';
-        window.setTimeout(() => (button.textContent = original), 2000);
-      } catch {
-        // Clipboard API unavailable (e.g. insecure context); leave the label.
-      }
-    });
-  }
-</script>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -664,9 +664,14 @@ a:focus {
 }
 
 .share-link {
+  display: inline-block;
   padding: var(--spacing-1) var(--spacing-3);
   font-family: var(--font-heading);
   font-size: var(--fontSize-0);
+
+  /* Match the tag chips' compact height: without this the inherited body
+     line-height pushed the pill outline too far apart vertically. */
+  line-height: 1.2;
   color: var(--color-primary);
   border: 1px solid var(--color-accent);
   border-radius: var(--radius-pill);


### PR DESCRIPTION
## Summary

Tidies up the post-footer "Udostępnij" (share) block: the controls were
visually too tall and the markup/script lived inline in `[...slug].astro`.

- **One abstraction for the buttons** — new `ShareLink.astro` renders each
  control, either as an outbound intent link (`href`) or as the copy-link
  button (`shareUrl`), sharing the `.share-link` pill styling.
- **One abstraction for the section** — new `Share.astro` owns the whole
  share block (label + controls), builds the X/LinkedIn intent URLs, and
  carries the copy-to-clipboard script so the section is self-contained.
  `[...slug].astro` now just renders `<Share title={title} />`.
- **Spacing/height fix** — `.share-link` gains `line-height: 1.2` so the
  pill outlines match the tag chips' height; the inherited body
  line-height had pushed the outlines too far apart vertically. Font size
  (`--fontSize-0`) and inter-control gap (`--spacing-2`) already match the
  breadcrumbs, so the controls now read consistently with both breadcrumbs
  and tags.

Rendered HTML for posts is byte-for-byte equivalent to before (same intent
URLs, same `data-share-url`, same copy script) — this is a behavior-
preserving refactor plus the height tweak.

## Testing

- `pnpm type:check` — 0 errors
- `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` — clean
- `pnpm test` — 87 passed
- `pnpm build` — completed; verified the rendered share section in `dist/`