### PR TITLE
fix: tighten share divider to hug its controls

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -46,6 +46,35 @@ for (const route of ['/bio/', '/contact/']) {
   });
 }
 
+test('share row keeps its divider close to the controls', async ({ page }) => {
+  await page.goto('/blog/');
+  const href = await page.locator('#blog-posts .post-list-item h2 a').first().getAttribute('href');
+  expect(href).toBeTruthy();
+  await page.goto(href as string);
+
+  const share = page.locator('article.blog-post .share');
+  const firstLink = share.locator('.share-link').first();
+  await expect(share).toBeVisible();
+  await expect(firstLink).toBeVisible();
+
+  // The top rule sits at the box edge; tight padding keeps it hugging the
+  // controls (the breadcrumb-style pairing), unlike the wide gap that opens
+  // the share row away from the section above it.
+  const shareBox = await share.boundingBox();
+  const linkBox = await firstLink.boundingBox();
+  expect(shareBox).not.toBeNull();
+  expect(linkBox).not.toBeNull();
+
+  const dividerGap = (linkBox?.y ?? 0) - (shareBox?.y ?? 0);
+  // Divider hugs the buttons (padding-top is --spacing-2 = 8px); guard against a
+  // regression back to the loose --spacing-6 (24px) that pushed it far away.
+  expect(dividerGap).toBeLessThanOrEqual(12);
+
+  // It must still be clearly set apart from the tags above it.
+  const marginTop = await share.evaluate(el => Number.parseFloat(getComputedStyle(el).marginTop));
+  expect(marginTop).toBeGreaterThan(12);
+});
+
 test('setup page server-renders a sized skeleton so the diagram does not jump', async ({ request }) => {
   const response = await request.get('/setup/');
   expect(response.ok()).toBeTruthy();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -647,14 +647,16 @@ a:focus {
 
 /* Share row: static intent links plus a copy-link button, below the tag list.
    A top rule (matching the site's <hr>: 1px, --color-accent) sets it apart from
-   the tags above. */
+   the tags above. The margin opens the gap above the rule; the rule itself hugs
+   the controls below it (tight padding) so the divider reads as belonging to the
+   share row — the same close pairing the breadcrumbs use with their separators. */
 .share {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-2);
   margin-top: var(--spacing-8);
-  padding-top: var(--spacing-6);
+  padding-top: var(--spacing-2);
   border-top: 1px solid var(--color-accent);
 }
 


### PR DESCRIPTION
## Summary

The share row's top rule sat `--spacing-6` (24px) above the buttons, reading as a detached line. Breadcrumb separators, by contrast, hug their content. This drops the share row's `padding-top` to `--spacing-2` (8px) so the divider hugs the controls, while keeping the `margin-top` above it to set the section apart from the tag list.

## Changes

- **`src/styles/main.css`** — `.share` `padding-top` from `var(--spacing-6)` → `var(--spacing-2)`; updated the comment to explain the close pairing (margin opens the gap above the rule; tight padding keeps the rule hugging the controls below).
- **`e2e/layout.spec.ts`** — added a regression guard `share row keeps its divider close to the controls` that measures the gap between `.share`'s top edge (where the rule sits) and its first button (≤ 12px), and still asserts a clear `margin-top` above the row.

## Verification

`type:check`, `lint:check`, `lint:css`, `format:check` and `test` (87 unit tests) all pass; production build succeeds and emits `padding-top:var(--spacing-2)` on `.share`. The Playwright e2e suite was not run locally (Chromium download is blocked in the build environment) — CI runs it.