### PR TITLE
fix: lengthen tag archive meta descriptions for SEO

### DIFF
--- a/src/lib/tags.test.ts
+++ b/src/lib/tags.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { __setEntries, type MockPost } from '../../test/mocks/astro-content';
-import { getTags } from './tags';
+import { getTags, postCountLabel, describeTagPage, type TagInfo } from './tags';
+import { DESCRIPTION_MAX_LENGTH } from './seo';
 
 const post = (id: string, date: string, tags: string[]): MockPost => ({ id, data: { date: new Date(date), tags } });
 
@@ -36,5 +37,35 @@ describe('getTags', () => {
   it('throws on a slug collision between two distinct tags', async () => {
     __setEntries([post('a', '2025-01-01', ['C++', 'C#'])]);
     await expect(getTags()).rejects.toThrow(/slug collision/);
+  });
+});
+
+describe('postCountLabel', () => {
+  it('uses the correct Polish plural form', () => {
+    expect(postCountLabel(1)).toBe('1 wpis');
+    expect(postCountLabel(2)).toBe('2 wpisy');
+    expect(postCountLabel(4)).toBe('4 wpisy');
+    expect(postCountLabel(5)).toBe('5 wpisów');
+    expect(postCountLabel(12)).toBe('12 wpisów');
+    expect(postCountLabel(22)).toBe('22 wpisy');
+  });
+});
+
+describe('describeTagPage', () => {
+  const tag = (name: string, count: number): TagInfo => ({ tag: name, slug: name, count, posts: [] });
+
+  it('includes the tag name and post count', () => {
+    const description = describeTagPage(tag('angular', 7));
+    expect(description).toContain('„angular”');
+    expect(description).toContain('7 wpisów');
+  });
+
+  it('is long enough to clear the "too short" audit yet within the SEO limit', () => {
+    const cases: TagInfo[] = [tag('ai', 1), tag('iot', 1), tag('shopping manager', 18), tag('home assistant', 1)];
+    for (const t of cases) {
+      const length = describeTagPage(t).length;
+      expect(length).toBeGreaterThanOrEqual(110);
+      expect(length).toBeLessThanOrEqual(DESCRIPTION_MAX_LENGTH);
+    }
   });
 });

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,5 +1,6 @@
 import { getBlogPosts } from './blog';
 import { slugifyTag } from './slugify-tag';
+import { plPlural } from './pl-plural';
 
 // Re-exported so existing server-side imports (`../lib/tags`) keep working; the
 // implementation lives in a dependency-free module the client search can import.
@@ -50,4 +51,18 @@ export async function getTags(): Promise<TagInfo[]> {
   }
 
   return [...byTag.values()].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag, 'pl'));
+}
+
+// "<n> wpis/wpisy/wpisów" with the correct Polish plural form for the count.
+export function postCountLabel(count: number): string {
+  return `${count} ${plPlural(count, ['wpis', 'wpisy', 'wpisów'])}`;
+}
+
+// Meta description for a tag archive page. Kept long enough to clear the
+// "meta description too short" SEO audit while staying within the 160-character
+// limit for every tag (longest current case ~146 chars).
+export function describeTagPage(tag: TagInfo): string {
+  return `Wpisy oznaczone tagiem „${tag.tag}” na blogu Dawida Ryłko — ${postCountLabel(
+    tag.count,
+  )}. Artykuły o programowaniu, technologiach i wytwarzaniu oprogramowania.`;
 }

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -5,7 +5,7 @@ import JsonLd from '../../components/JsonLd.astro';
 import PostListItem from '../../components/PostListItem.astro';
 import { SITE_METADATA } from '../../data/site-metadata';
 import { createPageSchema } from '../../lib/page-metadata';
-import { getTags, type TagInfo } from '../../lib/tags';
+import { getTags, postCountLabel, describeTagPage, type TagInfo } from '../../lib/tags';
 import { toISODate } from '../../lib/date';
 
 export const getStaticPaths = (async () => {
@@ -20,9 +20,7 @@ interface Props {
 const { tag } = Astro.props;
 
 const title = `Tag: ${tag.tag}`;
-const description = `Wpisy oznaczone tagiem „${tag.tag}” na blogu Dawida Ryłko — ${tag.count} ${
-  tag.count === 1 ? 'wpis' : 'wpisów'
-}.`;
+const description = describeTagPage(tag);
 
 const structuredData = createPageSchema({
   type: 'CollectionPage',
@@ -60,7 +58,7 @@ const structuredData = createPageSchema({
   <JsonLd data={structuredData} />
   <header>
     <h1>#{tag.tag}</h1>
-    <small>{tag.count} {tag.count === 1 ? 'wpis' : 'wpisów'}</small>
+    <small>{postCountLabel(tag.count)}</small>
   </header>
   <ol class="posts">
     {tag.posts.map(post => <PostListItem post={post} />)}


### PR DESCRIPTION
## Problem

Every tag archive page (`/tags/<slug>/`) emitted a meta description of only **60–76 characters**, which the Ahrefs audit flags as **"meta description too short"** across all tags.

The old template was just:

> Wpisy oznaczone tagiem „javascript” na blogu Dawida Ryłko — 7 wpisów.

## Fix

- Append a short descriptive clause about the blog's topics so each tag page now lands between **~130 and ~146 characters**, comfortably above the "too short" threshold and within the 160-character SEO limit enforced by `src/lib/seo.ts`.

  > Wpisy oznaczone tagiem „javascript” na blogu Dawida Ryłko — 7 wpisów. Artykuły o programowaniu, technologiach i wytwarzaniu oprogramowania.

- Extract the description into `describeTagPage()` and the post-count label into `postCountLabel()` in `src/lib/tags.ts`.
- `postCountLabel()` now uses the correct Polish plural form via `plPlural` — `2–4 → "wpisy"` instead of the previously incorrect `"wpisów"` (e.g. "4 wpisy" instead of "4 wpisów"). This also fixes the count shown in the page `<small>`.
- Add unit tests covering the plural forms and asserting every representative tag description stays within `[110, 160]` characters.

## Verification

- `pnpm test` — 90 passing
- `pnpm type:check`, `pnpm lint:check`, `pnpm format:check` — clean