### PR TITLE
fix: balance post-footer divider spacing below the share row

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -75,6 +75,31 @@ test('share row keeps its divider close to the controls', async ({ page }) => {
   expect(marginTop).toBeGreaterThan(12);
 });
 
+test('post-footer divider keeps the balanced breadcrumb-style spacing', async ({ page }) => {
+  await page.goto('/blog/');
+  const href = await page.locator('#blog-posts .post-list-item h2 a').first().getAttribute('href');
+  expect(href).toBeTruthy();
+  await page.goto(href as string);
+
+  const following = page.locator('.related, .blog-post-nav').first();
+  await expect(following).toBeVisible();
+
+  // The rule sits at the box edge, so margin-top is the gap above it and
+  // padding-top the gap below. Both should be the tight --spacing-6 (24px) the
+  // chrome dividers use — guard against a regression to the loose --spacing-8
+  // (32px) that opened a wide gap below the share row.
+  const { marginTop, paddingTop } = await following.evaluate(el => {
+    const style = getComputedStyle(el);
+    return {
+      marginTop: Number.parseFloat(style.marginTop),
+      paddingTop: Number.parseFloat(style.paddingTop),
+    };
+  });
+  expect(marginTop).toBeLessThanOrEqual(26);
+  expect(marginTop).toBeGreaterThan(12);
+  expect(Math.abs(marginTop - paddingTop)).toBeLessThanOrEqual(2);
+});
+
 test('setup page server-renders a sized skeleton so the diagram does not jump', async ({ request }) => {
   const response = await request.get('/setup/');
   expect(response.ok()).toBeTruthy();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -688,10 +688,12 @@ a:focus {
 
 /* Post-footer sections (related posts, prev/next nav) are each set off from the
    content above by the shared rule — 1px, --color-accent, matching the site's
-   <hr> — so the end of an article reads as distinct blocks. */
+   <hr> — so the end of an article reads as distinct blocks. Even --spacing-6 on
+   both sides of the rule keeps the same balanced pairing the breadcrumbs/bio
+   chrome use, instead of a loose gap opening above the divider. */
 .related,
 .blog-post-nav {
-  margin-top: var(--spacing-8);
+  margin-top: var(--spacing-6);
   padding-top: var(--spacing-6);
   border-top: 1px solid var(--color-accent);
 }


### PR DESCRIPTION
## What

Tightens the gap below the share row on blog posts so the divider above the "Powiązane wpisy" / prev-next section reads as a balanced pairing instead of leaving a loose band of empty space.

## Why

After #428 tightened the share divider to hug its controls, the next divider down (`.related` / `.blog-post-nav`) still opened a loose `--spacing-8` (2rem) gap **above** its rule while keeping only `--spacing-6` (1.5rem) **below** — an uneven band under the share row (visible as the highlighted margin in the report).

The site's chrome dividers (breadcrumbs/bio) use a balanced `--spacing-6` on both sides of the rule, which reads better. This change applies the same rhythm to the post-footer divider.

## Changes

- `src/styles/main.css`: `.related, .blog-post-nav` `margin-top` `--spacing-8` → `--spacing-6`, matching its `padding-top` for symmetric spacing around the rule.
- `e2e/layout.spec.ts`: new regression guard asserting the post-footer divider keeps the balanced `--spacing-6` (≈24px) on both sides, so it can't drift back to the loose `--spacing-8`.

## Verification

- `pnpm lint:css`, `pnpm format:check`, `pnpm lint:check`, `pnpm type:check`, `pnpm test` — all pass.
- `pnpm build` succeeds; compiled CSS confirms symmetric `--spacing-6` on both sides of the divider.
- E2E (Playwright) couldn't run locally (chromium download blocked by the environment's network policy); CI will exercise it.