### PR TITLE
fix(tables): stretch app-page tables to full width

### DIFF
--- a/src/components/Table.astro
+++ b/src/components/Table.astro
@@ -12,36 +12,38 @@ interface Props {
 const { data, header, widthConfig, ariaLabel } = Astro.props;
 ---
 
-<table aria-label={ariaLabel} tabindex="0">
-  {
-    widthConfig && (
-      <colgroup>
-        {widthConfig.map(width => (
-          <col class={`col-w-${width.replace('%', '').trim()}`} />
-        ))}
-      </colgroup>
-    )
-  }
-  {
-    header && (
-      <thead>
-        <tr>
-          {header.map(item => (
-            <th scope="col">{item}</th>
-          ))}
-        </tr>
-      </thead>
-    )
-  }
-  <tbody>
+<div class="table-scroll" tabindex="0">
+  <table aria-label={ariaLabel}>
     {
-      data.map(row => (
-        <tr>
-          {row.map(cell => (
-            <td>{cell}</td>
+      widthConfig && (
+        <colgroup>
+          {widthConfig.map(width => (
+            <col class={`col-w-${width.replace('%', '').trim()}`} />
           ))}
-        </tr>
-      ))
+        </colgroup>
+      )
     }
-  </tbody>
-</table>
+    {
+      header && (
+        <thead>
+          <tr>
+            {header.map(item => (
+              <th scope="col">{item}</th>
+            ))}
+          </tr>
+        </thead>
+      )
+    }
+    <tbody>
+      {
+        data.map(row => (
+          <tr>
+            {row.map(cell => (
+              <td>{cell}</td>
+            ))}
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+</div>

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -194,67 +194,69 @@ const structuredData = createPageSchema({
   <main>
     <section aria-labelledby="presentations-heading">
       <h2 id="presentations-heading">Presentations</h2>
-      <table class="presentations-table" data-presentations aria-label="Presentations" tabindex="0">
-        <colgroup>
-          <col class="col-w-5" />
-          <col class="col-w-20" />
-          <col class="col-w-20" />
-          <col class="col-w-10" />
-          <col class="col-w-15" />
-          <col class="col-w-30" />
-        </colgroup>
-        <thead>
-          <tr>
-            <th scope="col">#</th>
-            <th scope="col">Topic</th>
-            <th scope="col">Title</th>
-            <th scope="col">Lang</th>
-            <th scope="col">Size</th>
-            <th scope="col">Download</th>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            rows.map(row => (
-              <tr>
-                <td>{row.index}</td>
-                <td>{row.topic}</td>
-                <td>{row.title}</td>
-                <td>{row.language}</td>
-                <td>{row.size}</td>
-                <td>
-                  <div class="file-actions">
-                    {row.links.map(link =>
-                      link.action === 'open' ? (
-                        <a
-                          class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
-                          href={link.href}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={`Open ${link.title} ${link.type} in new tab`}
-                          title={`Open ${link.type} in new tab (${link.size})`}
-                        >
-                          {link.icon}
-                        </a>
-                      ) : (
-                        <a
-                          class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
-                          href={link.href}
-                          download={link.download}
-                          aria-label={`Download ${link.title} as ${link.type}`}
-                          title={`Download ${link.type} (${link.size})`}
-                        >
-                          {link.icon}
-                        </a>
-                      ),
-                    )}
-                  </div>
-                </td>
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
+      <div class="table-scroll" tabindex="0">
+        <table class="presentations-table" data-presentations aria-label="Presentations">
+          <colgroup>
+            <col class="col-w-5" />
+            <col class="col-w-20" />
+            <col class="col-w-20" />
+            <col class="col-w-10" />
+            <col class="col-w-15" />
+            <col class="col-w-30" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Topic</th>
+              <th scope="col">Title</th>
+              <th scope="col">Lang</th>
+              <th scope="col">Size</th>
+              <th scope="col">Download</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              rows.map(row => (
+                <tr>
+                  <td>{row.index}</td>
+                  <td>{row.topic}</td>
+                  <td>{row.title}</td>
+                  <td>{row.language}</td>
+                  <td>{row.size}</td>
+                  <td>
+                    <div class="file-actions">
+                      {row.links.map(link =>
+                        link.action === 'open' ? (
+                          <a
+                            class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
+                            href={link.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`Open ${link.title} ${link.type} in new tab`}
+                            title={`Open ${link.type} in new tab (${link.size})`}
+                          >
+                            {link.icon}
+                          </a>
+                        ) : (
+                          <a
+                            class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
+                            href={link.href}
+                            download={link.download}
+                            aria-label={`Download ${link.title} as ${link.type}`}
+                            title={`Download ${link.type} (${link.size})`}
+                          >
+                            {link.icon}
+                          </a>
+                        ),
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
     </section>
   </main>
 

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -81,58 +81,64 @@ const structuredData = createPageSchema({
   <main>
     <section id="site-info" aria-label="Site Information">
       <h2>Site Information</h2>
-      <table aria-label="Site information" tabindex="0">
-        <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
-        <thead><tr><th scope="col">Property</th><th scope="col">Value</th></tr></thead>
-        <tbody>
-          {
-            siteInfo.map(([prop, value]) => (
-              <tr>
-                <td>{prop}</td>
-                <td>{value}</td>
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
+      <div class="table-scroll" tabindex="0">
+        <table aria-label="Site information">
+          <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
+          <thead><tr><th scope="col">Property</th><th scope="col">Value</th></tr></thead>
+          <tbody>
+            {
+              siteInfo.map(([prop, value]) => (
+                <tr>
+                  <td>{prop}</td>
+                  <td>{value}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
     </section>
     <section id="pages" aria-label="Pages">
       <h2>Pages</h2>
-      <table aria-label="Pages" tabindex="0">
-        <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
-        <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
-        <tbody>
-          {
-            staticPages.map((p, i) => (
-              <tr>
-                <td>{i + 1}</td>
-                <td>
-                  <a href={p}>{p}</a>
-                </td>
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
+      <div class="table-scroll" tabindex="0">
+        <table aria-label="Pages">
+          <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
+          <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
+          <tbody>
+            {
+              staticPages.map((p, i) => (
+                <tr>
+                  <td>{i + 1}</td>
+                  <td>
+                    <a href={p}>{p}</a>
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
     </section>
     <section id="blog-posts" aria-label="Blog Posts">
       <h2>Blog Posts</h2>
-      <table aria-label="Blog posts" tabindex="0">
-        <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
-        <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
-        <tbody>
-          {
-            blogPaths.map((p, i) => (
-              <tr>
-                <td>{i + 1}</td>
-                <td>
-                  <a href={p}>{p}</a>
-                </td>
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
+      <div class="table-scroll" tabindex="0">
+        <table aria-label="Blog posts">
+          <colgroup><col class="col-w-10" /><col class="col-w-90" /></colgroup>
+          <thead><tr><th scope="col">#</th><th scope="col">Path</th></tr></thead>
+          <tbody>
+            {
+              blogPaths.map((p, i) => (
+                <tr>
+                  <td>{i + 1}</td>
+                  <td>
+                    <a href={p}>{p}</a>
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
     </section>
   </main>
 </PageLayout>

--- a/src/pages/setup.astro
+++ b/src/pages/setup.astro
@@ -181,29 +181,31 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
   <main>
     <section id="desktop" aria-labelledby="desktop-heading">
       <h2 id="desktop-heading">Desktop Setup</h2>
-      <table aria-label="Desktop hardware and equipment specifications" tabindex="0">
-        <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
-        <thead><tr><th scope="col">Type</th><th scope="col">Full Name</th></tr></thead>
-        <tbody>
-          {
-            desktopSetup.map(([type, name, link, details]) => (
-              <tr>
-                <td>{type}</td>
-                <td>
-                  {link ? (
-                    <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
-                      {name}
-                    </ExternalLink>
-                  ) : (
-                    name
-                  )}
-                  {details && ` (${details})`}
-                </td>
-              </tr>
-            ))
-          }
-        </tbody>
-      </table>
+      <div class="table-scroll" tabindex="0">
+        <table aria-label="Desktop hardware and equipment specifications">
+          <colgroup><col class="col-w-30" /><col class="col-w-70" /></colgroup>
+          <thead><tr><th scope="col">Type</th><th scope="col">Full Name</th></tr></thead>
+          <tbody>
+            {
+              desktopSetup.map(([type, name, link, details]) => (
+                <tr>
+                  <td>{type}</td>
+                  <td>
+                    {link ? (
+                      <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
+                        {name}
+                      </ExternalLink>
+                    ) : (
+                      name
+                    )}
+                    {details && ` (${details})`}
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
     </section>
 
     <section id="diagram" aria-labelledby="diagram-heading">
@@ -224,39 +226,41 @@ const sections: { id: string; heading: string; ariaLabel: string; items: SetupIt
         .map(({ id, heading, ariaLabel, items }) => (
           <section id={id} aria-labelledby={`${id}-heading`}>
             <h2 id={`${id}-heading`}>{heading}</h2>
-            <table aria-label={ariaLabel} tabindex="0">
-              <colgroup>
-                <>
-                  <col class="col-w-30" />
-                  <col class="col-w-70" />
-                </>
-              </colgroup>
-              <thead>
-                <tr>
+            <div class="table-scroll" tabindex="0">
+              <table aria-label={ariaLabel}>
+                <colgroup>
                   <>
-                    <th scope="col">Type</th>
-                    <th scope="col">Full Name</th>
+                    <col class="col-w-30" />
+                    <col class="col-w-70" />
                   </>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map(([type, name, link, details]) => (
+                </colgroup>
+                <thead>
                   <tr>
-                    <td>{type}</td>
-                    <td>
-                      {link ? (
-                        <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
-                          {name}
-                        </ExternalLink>
-                      ) : (
-                        name
-                      )}
-                      {details && ` (${details})`}
-                    </td>
+                    <>
+                      <th scope="col">Type</th>
+                      <th scope="col">Full Name</th>
+                    </>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {items.map(([type, name, link, details]) => (
+                    <tr>
+                      <td>{type}</td>
+                      <td>
+                        {link ? (
+                          <ExternalLink href={link} follow aria-label={`View ${name} on external site`}>
+                            {name}
+                          </ExternalLink>
+                        ) : (
+                          name
+                        )}
+                        {details && ` (${details})`}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </section>
         ))
     }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -351,6 +351,29 @@ table tr:last-child td {
   border-bottom: 0;
 }
 
+/* App-page tables (metadata, files, setup, bio) wrap in .table-scroll. A bare
+   display: block table only grows to its content width, so short tables (e.g.
+   the metadata #/Path lists) leave an ugly gap to the rounded border instead of
+   filling it. Here the wrapper owns the horizontal scroll and the rounded frame,
+   while the table inside becomes a real table again (width: 100%) so columns
+   stretch edge to edge — yet still overflow into a scroll when the content
+   (white-space: nowrap) is wider than the available room. */
+.table-scroll {
+  max-width: 100%;
+  margin-bottom: var(--spacing-8);
+  overflow-x: auto;
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-pill);
+}
+
+.table-scroll table {
+  display: table;
+  width: 100%;
+  margin-bottom: 0;
+  border: 0;
+  border-radius: 0;
+}
+
 /* Column width hints applied to <col> elements so width values stay out of
    inline styles. Tables scroll horizontally on small screens (table is
    display: block; overflow-x: auto above), so these only shape proportions


### PR DESCRIPTION
Wrap the metadata, files, setup and bio tables in a .table-scroll
container that owns the horizontal scroll and rounded frame, and make
the table itself a real display:table; width:100% again. A bare
display:block table only grows to its content width, so short tables
(e.g. the metadata #/Path lists) left an ugly gap to the rounded border
instead of filling it. Columns now stretch edge to edge while still
scrolling when the content is wider than the available room.