### PR TITLE
fix: hug the post-footer divider to the share row above it

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -75,7 +75,7 @@ test('share row keeps its divider close to the controls', async ({ page }) => {
   expect(marginTop).toBeGreaterThan(12);
 });
 
-test('post-footer divider keeps the balanced breadcrumb-style spacing', async ({ page }) => {
+test('post-footer divider hugs the share row above it', async ({ page }) => {
   await page.goto('/blog/');
   const href = await page.locator('#blog-posts .post-list-item h2 a').first().getAttribute('href');
   expect(href).toBeTruthy();
@@ -84,10 +84,11 @@ test('post-footer divider keeps the balanced breadcrumb-style spacing', async ({
   const following = page.locator('.related, .blog-post-nav').first();
   await expect(following).toBeVisible();
 
-  // The rule sits at the box edge, so margin-top is the gap above it and
-  // padding-top the gap below. Both should be the tight --spacing-6 (24px) the
-  // chrome dividers use — guard against a regression to the loose --spacing-8
-  // (32px) that opened a wide gap below the share row.
+  // The rule sits at the box edge, so margin-top is the gap above it (to the
+  // share row) and padding-top the gap below (to the section heading). The rule
+  // hugs the share row — a tight margin (--spacing-2 = 8px) — and opens its gap
+  // below, so it reads as closing the share block instead of floating midway
+  // between the two sections.
   const { marginTop, paddingTop } = await following.evaluate(el => {
     const style = getComputedStyle(el);
     return {
@@ -95,9 +96,8 @@ test('post-footer divider keeps the balanced breadcrumb-style spacing', async ({
       paddingTop: Number.parseFloat(style.paddingTop),
     };
   });
-  expect(marginTop).toBeLessThanOrEqual(26);
-  expect(marginTop).toBeGreaterThan(12);
-  expect(Math.abs(marginTop - paddingTop)).toBeLessThanOrEqual(2);
+  expect(marginTop).toBeLessThanOrEqual(12);
+  expect(paddingTop).toBeGreaterThan(marginTop);
 });
 
 test('setup page server-renders a sized skeleton so the diagram does not jump', async ({ request }) => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -688,12 +688,13 @@ a:focus {
 
 /* Post-footer sections (related posts, prev/next nav) are each set off from the
    content above by the shared rule — 1px, --color-accent, matching the site's
-   <hr> — so the end of an article reads as distinct blocks. Even --spacing-6 on
-   both sides of the rule keeps the same balanced pairing the breadcrumbs/bio
-   chrome use, instead of a loose gap opening above the divider. */
+   <hr> — so the end of an article reads as distinct blocks. The rule hugs the
+   share row above it (tight margin) and opens its gap below, before the section
+   heading — mirroring the share row's own top rule so the divider reads as
+   closing the share block rather than floating between the two sections. */
 .related,
 .blog-post-nav {
-  margin-top: var(--spacing-6);
+  margin-top: var(--spacing-2);
   padding-top: var(--spacing-6);
   border-top: 1px solid var(--color-accent);
 }


### PR DESCRIPTION
## What

Tightens the post-footer divider (above "Powiązane wpisy" / prev-next nav) so it hugs the share row instead of floating midway between the two sections.

## Why

#431 balanced the divider with `--spacing-6` on both sides. In practice that left the rule floating in the middle of the gap below the share buttons, reading as detached from both the share row above and the heading below.

The share row's own top rule hugs its controls (tight `padding-top`); this applies the same pairing to the divider below it — a tight `margin-top` so the rule sits right under the share buttons (closing the share block), with its gap opening below before the section heading.

## Changes

- `src/styles/main.css`: `.related, .blog-post-nav` `margin-top` `--spacing-6` → `--spacing-2`; `padding-top` stays `--spacing-6`.
- `e2e/layout.spec.ts`: updated the regression guard — the divider's top margin is now tight (≤12px) and smaller than the padding below it.

## Verification

- `pnpm lint:css`, `pnpm format:check`, `pnpm lint:check`, `pnpm type:check`, `pnpm test` — all pass.
- E2E (Playwright) couldn't run locally (chromium download blocked by the environment's network policy); CI exercises it.