### PR TITLE
docs(memoizacja): replace closing image and update its alt text

### DIFF
--- a/content/pl/2025-07-29--memoizacja-harry-potter-i-myslodsiewnia/index.mdx
+++ b/content/pl/2025-07-29--memoizacja-harry-potter-i-myslodsiewnia/index.mdx
@@ -269,7 +269,7 @@ Jednak, jak każda magia, wymaga ostrożności. Jej nadużywanie może mieć sku
 
 Jak w każdym potężnym zaklęciu, kluczem jest umiar i świadomość: **co warto zapamiętać, a co trzeba puścić wolno**.
 
-![Mem w stylu komiksowym, przypominającym prace Stana Lee, przedstawiający Dumbledore'a i Harry'ego Pottera stojących obok Myślodsiewni. Dumbledore, z długą siwą brodą i w okularach, uśmiecha się z zadowoleniem i wskazuje na Myślodsiewnię, mówiąc w dymku: 'Widzisz, Harry? Nie musimy już po raz setny przeliczać 'fib(35)'.' Harry, z potarganymi włosami i w okularach, wygląda na zmęczonego, ale z ulgą, a w dymku myśli mówi: 'Moja głowa już by tego nie zniosła!'. W tle widać regały z książkami i inne przedmioty z gabinetu Dumbledore'a. Wygenerowana przez AI.](./Dumbledore_i_Harry_przy_Myslodsiewni.png)
+![Ilustracja w stylu komiksowym, przypominającym prace Stana Lee, przedstawiająca Dumbledore'a i Harry'ego Pottera stojących obok Myślodsiewni. Dumbledore, z długą siwą brodą i w okularach, uśmiecha się z zadowoleniem i wskazuje dłońmi na kamienną misę, z której unosi się świetlista, srebrzysta nić wspomnień wirująca w środku. Harry, z potarganymi włosami i w okularach, w szacie Hogwartu z gryfońskim krawatem, wygląda na zmęczonego, ale z ulgą. W tle widać regały z książkami, gotyckie okno i inne przedmioty z gabinetu Dumbledore'a. Wygenerowana przez AI.](./Dumbledore_i_Harry_przy_Myslodsiewni.png)
 
 ## Źródła
 


### PR DESCRIPTION
## Summary

Replaces the final illustration in the "Memoizacja ⚡️ Harry Potter i Myślodsiewnia" post (`/memoizacja-harry-potter-i-myslodsiewnia/`) with a new version of the same Pensieve scene, this time **without the English speech bubbles**.

The alt text has been rewritten accordingly: the previous description quoted the dialogue from the bubbles, which no longer exists in the image. The new alt describes the dialogue-free scene — Dumbledore gesturing toward the swirling silvery memory in the stone basin, Harry beside him in his Hogwarts robe, set in Dumbledore's office.

## Changes

- `content/pl/2025-07-29--memoizacja-harry-potter-i-myslodsiewnia/Dumbledore_i_Harry_przy_Myslodsiewni.png` — new image
- `content/pl/.../index.mdx` — updated alt text

## Verification

- `pnpm build` ✓ (image optimizes well within the 1 MB/file dist budget)
- `pnpm type:check` ✓
- `pnpm lint:check` ✓
- `pnpm lint:css` ✓
- `pnpm format:check` ✓
- `pnpm test` ✓ (90 passed)