### PR TITLE
fix: decline tag count noun on tags index page

### DIFF
--- a/src/lib/tags.test.ts
+++ b/src/lib/tags.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { __setEntries, type MockPost } from '../../test/mocks/astro-content';
-import { getTags, postCountLabel, describeTagPage, type TagInfo } from './tags';
+import { getTags, postCountLabel, tagCountLabel, describeTagPage, type TagInfo } from './tags';
 import { DESCRIPTION_MAX_LENGTH } from './seo';
 
 const post = (id: string, date: string, tags: string[]): MockPost => ({ id, data: { date: new Date(date), tags } });
@@ -48,6 +48,17 @@ describe('postCountLabel', () => {
     expect(postCountLabel(5)).toBe('5 wpisów');
     expect(postCountLabel(12)).toBe('12 wpisów');
     expect(postCountLabel(22)).toBe('22 wpisy');
+  });
+});
+
+describe('tagCountLabel', () => {
+  it('uses the correct Polish plural form', () => {
+    expect(tagCountLabel(1)).toBe('1 tag');
+    expect(tagCountLabel(2)).toBe('2 tagi');
+    expect(tagCountLabel(4)).toBe('4 tagi');
+    expect(tagCountLabel(5)).toBe('5 tagów');
+    expect(tagCountLabel(12)).toBe('12 tagów');
+    expect(tagCountLabel(22)).toBe('22 tagi');
   });
 });
 

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -58,6 +58,11 @@ export function postCountLabel(count: number): string {
   return `${count} ${plPlural(count, ['wpis', 'wpisy', 'wpisów'])}`;
 }
 
+// "<n> tag/tagi/tagów" with the correct Polish plural form for the count.
+export function tagCountLabel(count: number): string {
+  return `${count} ${plPlural(count, ['tag', 'tagi', 'tagów'])}`;
+}
+
 // Meta description for a tag archive page. Kept long enough to clear the
 // "meta description too short" SEO audit while staying within the 160-character
 // limit for every tag (longest current case ~146 chars).

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -3,7 +3,7 @@ import PageLayout from '../../layouts/PageLayout.astro';
 import JsonLd from '../../components/JsonLd.astro';
 import { SITE_METADATA } from '../../data/site-metadata';
 import { createPageSchema } from '../../lib/page-metadata';
-import { getTags } from '../../lib/tags';
+import { getTags, tagCountLabel } from '../../lib/tags';
 import type { PageMetadata } from '../../types';
 
 const tags = await getTags();
@@ -47,7 +47,7 @@ const structuredData = createPageSchema({
   <header>
     <h1>{PAGE_METADATA.title}</h1>
   </header>
-  <p>Przeglądaj {tags.length} tagów i wybierz temat, który Cię interesuje.</p>
+  <p>Przeglądaj {tagCountLabel(tags.length)} i wybierz temat, który Cię interesuje.</p>
   <ul class="tags tag-cloud" aria-label="Wszystkie tagi">
     {
       tags.map(tag => (


### PR DESCRIPTION
## Problem

The tags index page (`/tags/`) hardcoded the noun `tagów` regardless of the
count, e.g. "Przeglądaj **22 tagów** i wybierz temat…". Polish requires the
*few* form here — it should read "**22 tagi**".

## Fix

Mirrors the existing `postCountLabel` pattern: add a `tagCountLabel` helper in
`src/lib/tags.ts` that uses the shared `plPlural` rule to pick the right form
(`tag` / `tagi` / `tagów`), and use it on the tags index page.

- `1` → `1 tag`
- `2`, `4`, `22` → `… tagi`
- `5`, `12` → `… tagów`

## Tests

Added a `tagCountLabel` unit test block in `src/lib/tags.test.ts` covering all
three plural forms (including the 22 edge case) to prevent regression.

## Scope check

Searched the codebase for other count + noun strings. The only remaining
declension is the blog search result counter in `blog/[...page].astro`, which
already inflects correctly (inline `pluralize`, client-side). No other
hardcoded count nouns were found.

## Verification

`pnpm type:check`, `pnpm lint:check`, `pnpm format:check` and `pnpm test`
(91 tests) all pass.