### PR TITLE
feat: zoom blog list thumbnails to crop source framing

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -514,6 +514,20 @@ a:focus {
   height: auto;
   aspect-ratio: 16 / 9;
   object-fit: cover;
+
+  /* Zoom slightly past the edges so any framing/border baked into the source
+     image is cropped away; overflow:hidden on .post-thumb clips the overshoot.
+     A purely visual transform, so it never shifts layout (no CLS). */
+  transform: scale(1.06);
+  transition: transform 0.4s ease;
+}
+
+/* Gentle zoom-in when the card is hovered, on pointer devices only. */
+@media (hover: hover) {
+  .post-list-item:hover .post-thumb img,
+  .post-list-item:hover .post-thumb picture img {
+    transform: scale(1.12);
+  }
 }
 
 @media (width >= 30rem) {


### PR DESCRIPTION
## Summary

Blog list thumbnails (blog index, tag archives, related posts and the dynamic search results) keep the current crop, but are now slightly zoomed past their edges so any framing/border baked into the source image is cropped out. A subtle hover zoom is added as a nice touch.

## Changes

In `src/styles/main.css`, on `.post-thumb img`:

- **Static zoom to hide framing** — `transform: scale(1.06)`. The image is still cropped via `object-fit: cover`, but the slight overshoot is clipped by the existing `overflow: hidden` on `.post-thumb`, removing edge borders.
- **Hover effect** — gentle `scale(1.12)` with `transition: transform 0.4s ease` when the card (`.post-list-item`) is hovered, limited to `@media (hover: hover)`.

## Lighthouse considerations

- **CLS = 0** — uses only `transform` (composited), which never affects layout, so no content shifts.
- **Performance** — no new assets or JS; `transform` is GPU-cheap.
- **Accessibility** — thumbnails remain `aria-hidden` / `tabindex="-1"` (duplicate of the title link); the existing global `prefers-reduced-motion` rule near-instantly shortens the transition for users who request reduced motion.

## Verification

`pnpm lint:css`, `pnpm format:check` and `pnpm type:check` all pass.