### PR TITLE
feat: increase blog thumbnail zoom to crop more framing

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -518,7 +518,7 @@ a:focus {
   /* Zoom slightly past the edges so any framing/border baked into the source
      image is cropped away; overflow:hidden on .post-thumb clips the overshoot.
      A purely visual transform, so it never shifts layout (no CLS). */
-  transform: scale(1.06);
+  transform: scale(1.1);
   transition: transform 0.4s ease;
 }
 
@@ -526,7 +526,7 @@ a:focus {
 @media (hover: hover) {
   .post-list-item:hover .post-thumb img,
   .post-list-item:hover .post-thumb picture img {
-    transform: scale(1.12);
+    transform: scale(1.16);
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #437. The previous crop zoom was a touch too small, so the static zoom on blog list thumbnails is increased and the hover animation is bumped analogously (keeping the same +0.06 hover increment).

## Changes

In `src/styles/main.css`, on `.post-thumb img`:

- **Static zoom:** `scale(1.06)` → `scale(1.1)` — crops a bit more of any framing/border baked into the source image (still clipped by the existing `overflow: hidden`).
- **Hover zoom:** `scale(1.12)` → `scale(1.16)` — kept proportional to the new base.

## Lighthouse considerations

Unchanged from #437: purely a `transform` (composited, no layout shift → CLS 0), no new assets or JS, and the global `prefers-reduced-motion` rule still near-instantly shortens the transition.

## Verification

`pnpm lint:css` and `pnpm format:check` pass.