### PR TITLE
fix(seo): type bio as ProfilePage and lock JSON-LD identity in CI

### DIFF
--- a/scripts/ci/check-seo-meta.mjs
+++ b/scripts/ci/check-seo-meta.mjs
@@ -16,6 +16,9 @@
  *   - blog post pages carry a BlogPosting JSON-LD node
  *   - blog post pages declare og:type=article + article:published_time
  *   - every page emits a WebSite JSON-LD node (site-wide search action)
+ *   - every inline Person node (the canonical #person) carries a non-empty
+ *     sameAs (the social profiles that anchor the author's identity)
+ *   - the /bio/ profile page is typed ProfilePage with a Person mainEntity
  *
  * Redirect stubs (meta-refresh pages such as /resume/) are skipped. Zero
  * dependencies; runs against the built output, it does NOT rebuild. Exits
@@ -68,6 +71,28 @@ function rootTypes(block) {
   } catch {
     return [];
   }
+}
+
+/** Every object node anywhere in a parsed JSON-LD block (depth-first). */
+function allNodes(value, acc = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) allNodes(item, acc);
+  } else if (value && typeof value === 'object') {
+    acc.push(value);
+    for (const key of Object.keys(value)) allNodes(value[key], acc);
+  }
+  return acc;
+}
+
+/** Parsed object nodes of every JSON-LD block on a page (nested included). */
+function allJsonLdNodes(html) {
+  return ldJsonBlocks(html).flatMap(block => {
+    try {
+      return allNodes(JSON.parse(block));
+    } catch {
+      return [];
+    }
+  });
 }
 
 function checkPage(page, html) {
@@ -131,6 +156,29 @@ function checkPage(page, html) {
           }
         }
       }
+    }
+  }
+
+  // The canonical Person node (#person) anchors the author's identity; wherever
+  // it is emitted as a full inline node (carrying a name, not just an {@id}
+  // reference) it must list the social profiles via sameAs, or knowledge-graph
+  // crawlers cannot reconcile the author across the web.
+  for (const node of allJsonLdNodes(html)) {
+    if (node['@type'] === 'Person' && node['@id'] === `${ORIGIN}/#person` && node.name) {
+      if (!Array.isArray(node.sameAs) || node.sameAs.length === 0) {
+        fail(`${page}: canonical Person node is missing a non-empty sameAs`);
+      }
+    }
+  }
+
+  // The /bio/ page is the author's profile: schema.org's ProfilePage with a
+  // Person mainEntity is the pattern Google expects, so lock it against a
+  // regression back to a bare WebPage.
+  if (page === 'bio/index.html') {
+    const profile = allJsonLdNodes(html).find(node => node['@type'] === 'ProfilePage');
+    if (!profile) fail(`${page}: bio page must emit a ProfilePage JSON-LD node`);
+    else if (profile.mainEntity?.['@type'] !== 'Person') {
+      fail(`${page}: ProfilePage mainEntity must be a Person`);
     }
   }
 

--- a/src/lib/page-metadata.test.ts
+++ b/src/lib/page-metadata.test.ts
@@ -26,6 +26,11 @@ describe('createPageSchema', () => {
     expect('author' in createPageSchema({ title: 'T', description: 'd', withAuthor: false })).toBe(false);
   });
 
+  it('supports the ProfilePage type', () => {
+    const schema = createPageSchema({ type: 'ProfilePage', title: 'About', description: 'd' });
+    expect(schema['@type']).toBe('ProfilePage');
+  });
+
   it('supports the CollectionPage type and merges extra fields', () => {
     const schema = createPageSchema({
       type: 'CollectionPage',

--- a/src/lib/page-metadata.ts
+++ b/src/lib/page-metadata.ts
@@ -6,7 +6,7 @@ import { STRUCTURED_DATA } from '../data/structured-data';
 // mainEntity, potentialAction…) are passed in via `extra`.
 const { person } = STRUCTURED_DATA;
 
-type PageSchemaType = 'WebPage' | 'CollectionPage';
+type PageSchemaType = 'WebPage' | 'CollectionPage' | 'ProfilePage';
 
 interface PageSchemaInput {
   type?: PageSchemaType;

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -71,6 +71,10 @@ const image = {
 const { person } = STRUCTURED_DATA;
 
 const structuredData = createPageSchema({
+  // ProfilePage is schema.org's type for an about/profile page; pairing it with
+  // mainEntity = the Person it describes is Google's recommended pattern and
+  // keeps the page node consistent with the site-wide #person node.
+  type: 'ProfilePage',
   title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
   keywords: PAGE_METADATA.keywords,


### PR DESCRIPTION
## Description

Validated the rendered JSON-LD across the whole `dist/` build against five criteria:

- **No errors** — every `application/ld+json` block parses and each root node carries `@context` + `@type`.
- **Person has `sameAs`** — the canonical `#person` node lists all four social profiles wherever it is inlined.
- **Blog posts have `BlogPosting`** — 40 `BlogPosting` nodes; no `og:type=article` page is missing one.
- **Homepage has `WebSite`** — the site-wide `WebSite` + `SearchAction` node is present.
- **Bio Person/ProfilePage consistency** — this was the one gap.

The `/bio/` page's `Person` node was already consistent with the site-wide `#person` node (same `@id`, `sameAs`, `mainEntity` = Person), but the page itself was a bare `WebPage` instead of `ProfilePage`. This change types it as `ProfilePage` with the Person as `mainEntity` — the pattern Google expects for a profile page.

To stop both invariants from silently regressing, the `dist/` structured-data contract (`scripts/ci/check-seo-meta.mjs`) is extended to assert that the canonical `Person` node carries a non-empty `sameAs`, and that `/bio/` emits a `ProfilePage` with a `Person` `mainEntity`.

`pnpm type:check`, `pnpm lint:check`, `pnpm format:check` and `pnpm test` (98 passing) all pass locally, as does the structured-data contract.

## Type of change

- [ ] feat — a new feature
- [x] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)