### PR TITLE
refactor: move decimal-ASCII easter egg from header to /metadata/ page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Audyt Ahrefs pilnuje długości i poprawności metadanych. Reguły poniżej doty
 
 - **Limity długości** (`src/lib/seo.ts`): `<title>` ≤ **60** znaków, `<meta name="description">` ≤ **160**. Zmieniając tytuł/opis strony statycznej (`src/pages/*`) lub fallback w `site-metadata.ts`, mieść się w limitach. Sprawdza je `scripts/ci/check-seo-lengths.mjs` (twardo dla stron własnych: `/`, `/blog/*`, `/bio/`, `/contact/`, `/setup/`, `/metadata/`, `/files/`; posty z `content/pl` tylko ostrzega — ich tytuł/opis pochodzą z frontmatteru autora).
 - **Tytuł strony głównej** budowany jest z `SITE_METADATA.title` + `titleTagline` (krótki, ≤60 z marką). `author.jobTitle` (pełny opis roli) jest dłuższy i służy tylko do Bio + JSON-LD — nie używaj go w `<title>`.
-- **Fallback opisu** (`SITE_METADATA.description`) musi być ≤160 i **bez** easter-egga „68 97 119…” (ten należy do nagłówka, nie do snippetu w SERP).
+- **Fallback opisu** (`SITE_METADATA.description`) musi być ≤160 i **bez** easter-egga „68 97 119…” (ten żyje na stronie `/metadata/` jako wiersz „Signature”, nie w snippecie w SERP).
 - **Canonical:** strony `noIndex` (np. 404) **nie** emitują `<link rel="canonical">` (wskazywałby na URL non-200). Pilnują tego `scripts/ci/check-seo-meta.mjs` i smoke test.
 - **Budżet obrazów:** każdy obraz w `dist/` ≤ **1 MB** (`scripts/ci/check-image-budget.mjs`). Istniejące, cięższe obrazy postów są tymczasowo na liście wyjątków (`image-budget-baseline.json`); **nowe** ponadwymiarowe obrazy blokują CI — optymalizuj/zmniejszaj źródło przed dodaniem. Po świadomej optymalizacji odśwież baseline: `node scripts/ci/check-image-budget.mjs --update-baseline`.
 

--- a/src/data/site-metadata.ts
+++ b/src/data/site-metadata.ts
@@ -8,8 +8,8 @@ export const SITE_METADATA = {
   // under the 60-char SEO limit. The full role copy lives in author.jobTitle.
   titleTagline: 'Software Engineer | Scalable, Secure Systems',
   // Fallback meta description for pages without their own. Kept ≤160 chars and
-  // free of the decimal-ASCII easter egg (that belongs in the header, not in
-  // search snippets).
+  // free of the decimal-ASCII easter egg (that lives on the /metadata/ page, not
+  // in search snippets).
   description: {
     en: 'Personal website and blog of Dawid Ryłko, Software Engineer—articles and insights on software architecture, scalable systems, and modern web.',
     pl: 'Osobista strona i blog Dawida Ryłko, Software Engineera — artykuły o architekturze systemów, skalowalności i nowoczesnym wytwarzaniu oprogramowania.',

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -69,8 +69,6 @@ const {
 const metaLang = lang ?? SITE_METADATA.lang;
 const pathname = Astro.url.pathname;
 const isRootPath = pathname === '/';
-// Base64-of-decimal-ASCII easter egg carried over from the Gatsby header.
-const fakeTitle = '68 97 119 105 100 32 82 121 108 107 111';
 const canonical = new URL(pathname, Astro.site).href;
 const year = new Date().getFullYear();
 
@@ -144,7 +142,7 @@ const { website } = STRUCTURED_DATA;
   <body>
     <div class="global-wrapper" data-is-root-path={isRootPath}>
       <header class="header">
-        <div class="header-title">{fakeTitle}</div>
+        <div class="header-title"><a href="/">{SITE_METADATA.title}</a></div>
         <Menu />
       </header>
       <main><slot /></main>

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -36,7 +36,7 @@ describe('resolveMetaDescription', () => {
   it('keeps the fallback site descriptions within the SEO limit and free of the ASCII easter egg', () => {
     for (const description of Object.values(SITE_METADATA.description)) {
       expect(isWithinDescriptionLimit(description)).toBe(true);
-      // The decimal-ASCII header easter egg must not leak into search snippets.
+      // The decimal-ASCII signature easter egg must not leak into search snippets.
       expect(description).not.toMatch(/\b68 97 119\b/);
     }
   });

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -32,12 +32,17 @@ const aiResources: [string, string][] = [
   ['/sitemap-index.xml', 'Canonical list of all URLs.'],
 ];
 
+// Decimal-ASCII signature — easter egg relocated here from the site header so it
+// is no longer the first text content of every page. Decode for the nod.
+const signature = '68 97 119 105 100 32 82 121 108 107 111';
+
 const siteInfo: [string, string][] = [
   ['Title', siteTitle],
   ['Description', siteDescription],
   ['Build time', buildTime],
   ['Pages', staticPages.length.toString()],
   ['Blog posts', blogPaths.length.toString()],
+  ['Signature', signature],
 ];
 
 const PAGE_METADATA: PageMetadata = {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -641,6 +641,16 @@ a:focus {
   hyphens: auto;
 }
 
+.header-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.header-title a:hover,
+.header-title a:focus-visible {
+  text-decoration: underline;
+}
+
 .menu {
   margin-bottom: var(--spacing-4);
 }


### PR DESCRIPTION
## Description

The header brand rendered a decimal-ASCII string (`68 97 119 105 100 32 82 121 108 107 111`) as the first text content before `<main>` on every page. Audits flag this as a SEO/accessibility issue — the leading content of each page is a string of numbers instead of a readable name.

This PR:

- Replaces the header brand with a readable `Dawid Ryłko` wordmark linking to home (`src/layouts/PageLayout.astro`), with matching `.header-title a` styles (`src/styles/main.css`).
- Relocates the easter egg to the `/metadata/` page as a `Signature` row in the Site Information table (`src/pages/metadata.astro`), where it sits naturally alongside the site's technical metadata and next to the existing hidden "Metadata" footer link.
- Updates related comments to reflect the egg's new home (`src/data/site-metadata.ts`, `src/lib/seo.test.ts`, `CLAUDE.md`). The SEO guard keeping the ASCII out of meta descriptions stays in place.

The raw decimal string is preserved as-is — decoding remains a puzzle for the curious.

## Type of change

- [ ] feat — a new feature
- [ ] fix — a bug fix
- [x] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)