### PR TITLE
fix(home): add spacing above the CTA section

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -581,6 +581,13 @@ a:focus {
   }
 }
 
+/* The CTA section has no heading, so it misses the section-to-section gap that a
+   heading's top margin normally provides. Re-add it so the call to action does
+   not sit flush against the capabilities grid above. */
+#cta {
+  margin-top: var(--spacing-12);
+}
+
 /* Mobile-first author card: stacked and centred on phones; horizontal from the
    sm breakpoint up. */
 .bio {


### PR DESCRIPTION
## Description

On the homepage, the closing CTA ("Interested in working together? …") sat flush against the "What I do" capabilities grid above it, with no separating gap. Other sections get their vertical separation from the leading heading's `margin-top` (`--spacing-12`), but the CTA section has no heading, so it received no top spacing and `.capabilities` carries `margin: 0`. This adds an explicit `margin-top` to `#cta` to restore the section-to-section rhythm.

## Type of change

- [ ] feat — a new feature
- [x] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)