### PR TITLE
feat(files): enrich presentations table with descriptive metadata

### DIFF
--- a/src/lib/presentations.test.ts
+++ b/src/lib/presentations.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { parseFileName, formatFileSize, parsePresentationMetadata } from './presentations';
+
+describe('parseFileName', () => {
+  it('parses a well-formed presentation filename', () => {
+    expect(parseFileName('js_01_node_pl')).toEqual({
+      topic: 'js',
+      order: 1,
+      title: 'node',
+      language: 'PL',
+    });
+  });
+
+  it('keeps multi-segment titles intact', () => {
+    expect(parseFileName('js_03_npm_tools_pl')).toEqual({
+      topic: 'js',
+      order: 3,
+      title: 'npm_tools',
+      language: 'PL',
+    });
+  });
+
+  it('returns null when there are too few segments', () => {
+    expect(parseFileName('js_01_node')).toBeNull();
+    expect(parseFileName('readme')).toBeNull();
+  });
+});
+
+describe('formatFileSize', () => {
+  it('formats zero bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('formats kilobytes and megabytes', () => {
+    expect(formatFileSize(1024)).toBe('1 KB');
+    expect(formatFileSize(1024 * 1024)).toBe('1 MB');
+    expect(formatFileSize(3288020)).toBe('3.14 MB');
+  });
+});
+
+describe('parsePresentationMetadata', () => {
+  const csv = [
+    'filename,title,subject,keywords',
+    'js_01_node_pl,"JavaScript | Wstęp do Node.js - NODE, NVM, NPM…","Node.js","JavaScript, Node.js, NVM, NPM"',
+    'js_02_npm_pl,"JavaScript | NPM - package.json, zależności…","NPM","JavaScript, NPM, package.json"',
+  ].join('\n');
+
+  it('maps each filename to its descriptive metadata', () => {
+    const map = parsePresentationMetadata(csv);
+    expect(map.get('js_01_node_pl')).toEqual({
+      title: 'JavaScript | Wstęp do Node.js - NODE, NVM, NPM…',
+      subject: 'Node.js',
+      keywords: 'JavaScript, Node.js, NVM, NPM',
+    });
+  });
+
+  it('keeps commas inside quoted fields', () => {
+    const map = parsePresentationMetadata(csv);
+    expect(map.get('js_02_npm_pl')?.title).toBe('JavaScript | NPM - package.json, zależności…');
+    expect(map.get('js_02_npm_pl')?.keywords).toBe('JavaScript, NPM, package.json');
+  });
+
+  it('ignores the header row and blank lines', () => {
+    const map = parsePresentationMetadata(`${csv}\n\n`);
+    expect(map.has('filename')).toBe(false);
+    expect(map.size).toBe(2);
+  });
+
+  it('returns an empty map for empty input', () => {
+    expect(parsePresentationMetadata('').size).toBe(0);
+  });
+
+  it('unescapes doubled quotes inside a field', () => {
+    const map = parsePresentationMetadata('filename,title,subject,keywords\nx_01_y_pl,"A ""quoted"" title","S","k"');
+    expect(map.get('x_01_y_pl')?.title).toBe('A "quoted" title');
+  });
+});

--- a/src/lib/presentations.ts
+++ b/src/lib/presentations.ts
@@ -1,0 +1,86 @@
+// Pure helpers behind the /files presentations table. The file-system read stays
+// in the page (files.astro); everything testable lives here.
+
+export type ParsedFileName = { topic: string; order: number; title: string; language: string };
+
+// Presentation files follow `topic_order_title_language` (e.g. `js_01_node_pl`).
+// Returns null for anything that does not match so the page can skip it.
+export const parseFileName = (fileName: string): ParsedFileName | null => {
+  const parts = fileName.split('_');
+  if (parts.length < 4) {
+    return null;
+  }
+  const [topic, orderRaw] = parts;
+  const languageRaw = parts[parts.length - 1];
+  if (topic === undefined || orderRaw === undefined || languageRaw === undefined) {
+    return null;
+  }
+  return {
+    topic,
+    order: parseInt(orderRaw, 10),
+    title: parts.slice(2, -1).join('_'),
+    language: languageRaw.toUpperCase(),
+  };
+};
+
+export const formatFileSize = (bytes: number): string => {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+};
+
+export type PresentationMeta = { title: string; subject: string; keywords: string };
+
+// Split a single CSV row into fields, honouring double-quoted fields that may
+// contain commas. A doubled quote ("") inside a quoted field is a literal quote.
+const parseCsvRow = (row: string): string[] => {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < row.length; i++) {
+    const char = row[i];
+    if (inQuotes) {
+      if (char === '"' && row[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else if (char === '"') {
+        inQuotes = false;
+      } else {
+        current += char;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      fields.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  fields.push(current);
+  return fields;
+};
+
+// Parse the presentations `metadata.csv` (the single source of truth for PDF
+// document metadata, enforced by the pre-commit validator) into a
+// filename → metadata map. Reusing it here gives the public table descriptive
+// titles, subjects and keywords instead of terse filename fragments. The header
+// row (`filename,title,subject,keywords`) is skipped.
+export const parsePresentationMetadata = (csv: string): Map<string, PresentationMeta> => {
+  const map = new Map<string, PresentationMeta>();
+  const lines = csv.split(/\r?\n/).filter(line => line.trim() !== '');
+  for (const line of lines.slice(1)) {
+    const [filename, title, subject, keywords] = parseCsvRow(line);
+    if (!filename) {
+      continue;
+    }
+    map.set(filename, {
+      title: title ?? '',
+      subject: subject ?? '',
+      keywords: keywords ?? '',
+    });
+  }
+  return map;
+};

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -4,6 +4,8 @@ import path from 'node:path';
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
 import { createPageSchema } from '../lib/page-metadata';
+import { parseFileName, formatFileSize, parsePresentationMetadata } from '../lib/presentations';
+import { SITE_METADATA } from '../data/site-metadata';
 import type { PageMetadata } from '../types';
 
 // Replaces Gatsby's custom `StaticFile` sourceNodes: read the same static/files
@@ -38,6 +40,15 @@ const readFilesRecursively = (dir: string, baseDir: string): FileNode[] => {
 
 const nodes = readFilesRecursively(filesDir, filesDir).filter(node => node.extension !== 'csv');
 
+// metadata.csv is the source of truth for each presentation's document metadata
+// (title/subject/keywords) and is kept in sync with the PDFs by the pre-commit
+// validator. Reusing it here gives the public table — and search engines —
+// descriptive titles and context instead of terse filename fragments.
+const metadataCsvPath = path.join(filesDir, 'presentations', 'metadata.csv');
+const presentationMeta = fs.existsSync(metadataCsvPath)
+  ? parsePresentationMetadata(fs.readFileSync(metadataCsvPath, 'utf8'))
+  : new Map();
+
 type FileAction = 'download' | 'open';
 type FileConfig = { icon: string; type: string; action: FileAction; hidden: boolean };
 
@@ -49,34 +60,6 @@ const FILE_CONFIG: Record<string, FileConfig[]> = {
   key: [{ icon: '🎨', type: 'Keynote', action: 'download', hidden: true }],
   ppt: [{ icon: '📊', type: 'PowerPoint', action: 'download', hidden: true }],
   pptx: [{ icon: '📊', type: 'PowerPoint', action: 'download', hidden: true }],
-};
-
-type ParsedFileName = { topic: string; order: number; title: string; language: string };
-
-const parseFileName = (fileName: string): ParsedFileName | null => {
-  const parts = fileName.split('_');
-  if (parts.length < 4) {
-    return null;
-  }
-  const [topic, orderRaw] = parts;
-  const languageRaw = parts[parts.length - 1];
-  if (topic === undefined || orderRaw === undefined || languageRaw === undefined) {
-    return null;
-  }
-  return {
-    topic,
-    order: parseInt(orderRaw, 10),
-    title: parts.slice(2, -1).join('_'),
-    language: languageRaw.toUpperCase(),
-  };
-};
-
-const formatFileSize = (bytes: number): string => {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 };
 
 const groupFilesByIdentity = (files: FileNode[]): Map<string, FileNode[]> =>
@@ -110,6 +93,14 @@ const rows = sortedEntries
     if (!parsed || !files[0]) return null;
     const pdfFile = files.find(f => f.extension.toLowerCase() === 'pdf');
     const sizeSource = pdfFile ?? files[0];
+    // Prefer the descriptive metadata.csv title/subject; fall back to a
+    // humanised filename fragment when an entry is missing from the CSV.
+    const meta = presentationMeta.get(files[0].name);
+    const fallbackTitle = parsed.title.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+    const displayTitle = meta?.title || fallbackTitle;
+    const topic = meta?.subject || parsed.topic.toUpperCase();
+    const keywords = meta?.keywords ?? '';
+    const downloadLabel = meta?.subject || fallbackTitle;
     const links = [...files]
       .sort((a, b) => {
         const ia = orderKeys.indexOf(a.extension.toLowerCase());
@@ -126,16 +117,18 @@ const rows = sortedEntries
           // the cmd/ctrl+shift+. shortcut reveals them (see the inline script).
           hidden: config.hidden,
           size: formatFileSize(file.size),
-          title: parsed.title,
-          download: `${parsed.title} - Dawid Ryłko - dawidrylko.com.${file.extension}`,
+          title: displayTitle,
+          download: `${downloadLabel} - Dawid Ryłko - dawidrylko.com.${file.extension}`,
         })),
       );
     return {
       index: index + 1,
-      topic: parsed.topic.toUpperCase(),
-      title: parsed.title,
+      topic,
+      title: displayTitle,
+      keywords,
       language: parsed.language,
       size: formatFileSize(sizeSource.size),
+      openHref: pdfFile?.publicURL ?? files[0].publicURL,
       links,
     };
   })
@@ -180,7 +173,24 @@ const structuredData = createPageSchema({
       '@type': 'ItemList',
       name: 'Presentation Files',
       description: 'Collection of downloadable technical presentations and educational materials',
-      numberOfItems: grouped.size,
+      numberOfItems: rows.length,
+      // Each row is exposed as a concrete DigitalDocument so search engines see
+      // titled, described items rather than an opaque file table.
+      itemListElement: rows.map(row => ({
+        '@type': 'ListItem',
+        position: row.index,
+        item: {
+          '@type': 'DigitalDocument',
+          name: row.title,
+          ...(row.topic ? { about: row.topic } : {}),
+          ...(row.keywords ? { keywords: row.keywords } : {}),
+          inLanguage: row.language.toLowerCase(),
+          encodingFormat: 'application/pdf',
+          url: `${SITE_METADATA.url}${row.openHref}`,
+          author: { '@id': `${SITE_METADATA.url}/#person` },
+          isAccessibleForFree: true,
+        },
+      })),
     },
   },
 });
@@ -194,21 +204,28 @@ const structuredData = createPageSchema({
   <main>
     <section aria-labelledby="presentations-heading">
       <h2 id="presentations-heading">Presentations</h2>
+      <p class="presentations-intro">
+        Slides from my technical talks and workshops on Node.js, JavaScript, and modern web development. Each
+        presentation opens or downloads as a PDF — titles link straight to the document.
+      </p>
       <div class="table-scroll" tabindex="0">
-        <table class="presentations-table" data-presentations aria-label="Presentations">
+        <table class="presentations-table" data-presentations>
+          <caption class="visually-hidden">
+            Technical presentations by Dawid Ryłko, each available to view or download as a PDF.
+          </caption>
           <colgroup>
             <col class="col-w-5" />
-            <col class="col-w-20" />
+            <col class="col-w-35" />
             <col class="col-w-20" />
             <col class="col-w-10" />
-            <col class="col-w-15" />
-            <col class="col-w-30" />
+            <col class="col-w-10" />
+            <col class="col-w-20" />
           </colgroup>
           <thead>
             <tr>
               <th scope="col">#</th>
+              <th scope="col">Presentation</th>
               <th scope="col">Topic</th>
-              <th scope="col">Title</th>
               <th scope="col">Lang</th>
               <th scope="col">Size</th>
               <th scope="col">Download</th>
@@ -219,8 +236,19 @@ const structuredData = createPageSchema({
               rows.map(row => (
                 <tr>
                   <td>{row.index}</td>
+                  <td class="presentation-cell">
+                    <a
+                      class="presentation-title"
+                      href={row.openHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Open ${row.title} (PDF) in a new tab`}
+                    >
+                      {row.title}
+                    </a>
+                    {row.keywords && <span class="presentation-keywords">{row.keywords}</span>}
+                  </td>
                   <td>{row.topic}</td>
-                  <td>{row.title}</td>
                   <td>{row.language}</td>
                   <td>{row.size}</td>
                   <td>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -431,6 +431,44 @@ table tr:last-child td {
   width: 90%;
 }
 
+/* Visually hide content while keeping it available to assistive tech and
+   crawlers (e.g. a descriptive <caption> that would duplicate the visible
+   intro). Standard clip-path inset pattern. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Files page: short lead-in above the presentations table. */
+.presentations-intro {
+  max-width: 60ch;
+}
+
+/* The presentation title cell carries long descriptive text (the document title
+   plus a keyword line); let it wrap instead of inheriting the table-wide
+   white-space: nowrap, which would force a wide horizontal scroll. */
+.presentations-table .presentation-cell {
+  white-space: normal;
+}
+
+.presentation-title {
+  font-weight: 600;
+}
+
+.presentation-keywords {
+  display: block;
+  margin-top: var(--spacing-1);
+  color: var(--color-text-light);
+  font-size: var(--fontSize-0);
+}
+
 /* Download actions cell on the files page: keep icons in a row. */
 .file-actions {
   display: flex;


### PR DESCRIPTION
## Description

The public `/files` presentations table was hard to read and gave crawlers almost no context: titles were derived from filename fragments (e.g. `js_03_npm_pl` rendered as just "npm") and the only links were emoji icons (`↗️` / `📄`) with zero anchor-text meaning. Meanwhile the rich `metadata.csv` — already the single source of truth for the PDFs' embedded document metadata, enforced by the pre-commit validator — sat completely unused by the page.

This PR reuses that CSV to make the table descriptive for both humans and search engines:

- Extract `parseFileName` / `formatFileSize` and a new quote-aware CSV parser into `src/lib/presentations.ts` (with unit tests), per the repo's "pure logic lives in `src/lib`" convention.
- Render each presentation **title as a real text link** to the PDF (strong anchor text), with a **keyword line** beneath it.
- Use the document **subject as the Topic** column (e.g. `Node.js`, `NPM`) instead of the terse `JS`, and build cleaner download filenames from it.
- Add an **intro paragraph** and a screen-reader **`<caption>`** for context.
- Expand the JSON-LD `ItemList` into per-item **`DigitalDocument`** entries (`name`, `about`, `keywords`, `inLanguage`, `url`, `encodingFormat`, `author`, `isAccessibleForFree`).
- Add a reusable `.visually-hidden` utility and presentation styles, including a wrapping override so long titles wrap within their column instead of forcing horizontal scroll.

No PDFs or `metadata.csv` were modified; existing post URLs are untouched.

## Type of change

- [x] feat — a new feature
- [ ] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)