### PR TITLE
feat: reuse 'What I do' capability areas on about and contact pages

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -35,11 +35,13 @@ test('blog post separates its tag list from the following section', async ({ pag
 // The global ul/ol reset strips padding and uses outside markers, which the
 // wrapper's overflow-x: hidden would clip. Content sections must re-add the
 // gutter so bullets stay on screen (regression: bio/contact lists ran off the
-// left edge while blog posts were fine).
+// left edge while blog posts were fine). The `.capabilities` card grid is
+// excluded: it is a marker-less layout grid (list-style: none) by design, not a
+// prose list, so it has no gutter to guard.
 for (const route of ['/bio/', '/contact/']) {
   test(`${route} content list keeps room for its bullet markers`, async ({ page }) => {
     await page.goto(route);
-    const list = page.locator('main section ul').first();
+    const list = page.locator('main section ul:not(.capabilities)').first();
     await expect(list).toBeVisible();
     const paddingLeft = await list.evaluate(el => Number.parseFloat(getComputedStyle(el).paddingLeft));
     expect(paddingLeft).toBeGreaterThan(0);

--- a/src/data/capabilities.ts
+++ b/src/data/capabilities.ts
@@ -1,0 +1,22 @@
+// Single source of truth for the six areas of work shown across the site.
+// Pages (home, about, contact) each supply their own framing for these areas,
+// so the set stays consistent everywhere without duplicating descriptive copy.
+export const CAPABILITY_AREAS = [
+  'Web platforms',
+  'Mobile apps',
+  'Architecture & infrastructure',
+  'AI integration',
+  'Cybersecurity',
+  'Technical leadership',
+] as const;
+
+export type CapabilityArea = (typeof CAPABILITY_AREAS)[number];
+
+// Helper to keep a page's per-area copy in the shared order and guarantee — via
+// the Record type — that every area is described and none drift out of sync.
+export function buildCapabilities(descriptions: Record<CapabilityArea, string>): {
+  term: CapabilityArea;
+  description: string;
+}[] {
+  return CAPABILITY_AREAS.map(term => ({ term, description: descriptions[term] }));
+}

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -7,6 +7,7 @@ import ExternalLink from '../components/ExternalLink.astro';
 import motto from '../assets/motto.jpg';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
+import { buildCapabilities } from '../data/capabilities';
 import { createPageSchema } from '../lib/page-metadata';
 import type { PageMetadata } from '../types';
 
@@ -62,6 +63,23 @@ const citations = [
     extraDetails: [{ type: 'translation', note: 'Translated by ChatGPT.' }],
   },
 ];
+
+// About framing of the shared capability areas: where the experience comes from,
+// written from a track-record angle rather than the home page's tagline style.
+const capabilities = buildCapabilities({
+  'Web platforms':
+    'A decade building React, Angular, and TypeScript frontends on top of Node.js APIs—the backbone of my day-to-day engineering work.',
+  'Mobile apps':
+    'Led cross-platform mobile development end to end, carrying products from prototype through release on the App Store and Google Play.',
+  'Architecture & infrastructure':
+    'Designing systems together with the CI/CD pipelines and automation around them, so teams can ship with confidence.',
+  'AI integration':
+    'Folding LLMs and AI-driven features into production software instead of leaving them as throwaway proofs of concept.',
+  Cybersecurity:
+    'A long-standing focus on security that shapes how I review, harden, and reason about everything I build.',
+  'Technical leadership':
+    'Years of leading and mentoring engineers and setting technical direction as teams and products grow.',
+});
 
 const image = {
   alt: `Graffiti on a utility box featuring a black-and-white image of Charlie Chaplin with the quote: 'A day without laughter is a day wasted'.`,
@@ -148,6 +166,19 @@ const structuredData = createPageSchema({
       <ExternalLink href="https://dawid.dev" follow>dawid.dev</ExternalLink> to see experiments, articles, and insights on
       technology and software craftsmanship.
     </p>
+  </section>
+  <section id="what-i-do">
+    <h2>What I do</h2>
+    <ul class="capabilities">
+      {
+        capabilities.map(({ term, description }) => (
+          <li>
+            <strong>{term}</strong>
+            {description}
+          </li>
+        ))
+      }
+    </ul>
   </section>
   <section id="philosophy">
     <h2>Philosophy</h2>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,6 +4,7 @@ import JsonLd from '../components/JsonLd.astro';
 import ExternalLink from '../components/ExternalLink.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
+import { buildCapabilities } from '../data/capabilities';
 import { createPageSchema } from '../lib/page-metadata';
 import type { PageMetadata } from '../types';
 
@@ -27,6 +28,17 @@ const author = SITE_METADATA.author;
 const social = SITE_METADATA.social;
 const { person } = STRUCTURED_DATA;
 
+// Contact framing of the shared capability areas: short, engagement-oriented
+// lines describing what we can work on together, distinct from the home/about copy.
+const capabilities = buildCapabilities({
+  'Web platforms': 'Building or scaling React, Angular, and TypeScript products with Node.js backends.',
+  'Mobile apps': 'Taking a cross-platform mobile idea from prototype to the App Store and Google Play.',
+  'Architecture & infrastructure': 'Shaping architecture, CI/CD, and infrastructure for fast, predictable releases.',
+  'AI integration': 'Adding LLM and AI-driven features that actually make it into production.',
+  Cybersecurity: 'Security reviews and hardening for systems that need to stay resilient.',
+  'Technical leadership': 'Leading an engineering team or providing senior technical direction.',
+});
+
 const structuredData = createPageSchema({
   title: PAGE_METADATA.title,
   description: PAGE_METADATA.description,
@@ -47,17 +59,22 @@ const structuredData = createPageSchema({
       make a real impact.
     </p>
     <p>
-      I work across the entire <strong>technology stack</strong> - from user-friendly <strong
-        >frontend interfaces</strong
-      >
-      {' '}and robust <strong>backend systems</strong> to <strong>cloud infrastructure</strong>,{' '}
-      <strong>AI-driven features</strong>, and advanced <strong>security implementations</strong>. Every solution I
-      build is <strong>scalable</strong>, <strong>maintainable</strong>, and <strong>designed to last</strong>.
-    </p>
-    <p>
       Whether you're starting from scratch or improving an existing platform, I bring a{' '}
       <strong>strategic and pragmatic mindset</strong> to ensure your technology supports long-term business goals.
     </p>
+  </section>
+  <section id="what-i-do">
+    <h2>What we can work on</h2>
+    <ul class="capabilities">
+      {
+        capabilities.map(({ term, description }) => (
+          <li>
+            <strong>{term}</strong>
+            {description}
+          </li>
+        ))
+      }
+    </ul>
   </section>
   <section>
     <h2>How to Reach Me</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import PageLayout from '../layouts/PageLayout.astro';
 import JsonLd from '../components/JsonLd.astro';
 import { STRUCTURED_DATA } from '../data/structured-data';
+import { buildCapabilities } from '../data/capabilities';
 import { createPageSchema } from '../lib/page-metadata';
 import type { PageMetadata } from '../types';
 
@@ -21,38 +22,21 @@ const PAGE_METADATA: PageMetadata = {
   ],
 };
 
-// Concrete areas of work shown in the "What I do" block. Kept as a single source
-// of truth so the visible list and the JSON-LD ItemList below never drift apart.
-const CAPABILITIES: { term: string; description: string }[] = [
-  {
-    term: 'Web platforms',
-    description:
-      'Production frontends in React, Angular, and TypeScript, backed by Node.js APIs—shipped end to end, from first commit to deployment.',
-  },
-  {
-    term: 'Mobile apps',
-    description: 'Cross-platform mobile applications taken from prototype to the App Store and Google Play.',
-  },
-  {
-    term: 'Architecture & infrastructure',
-    description:
-      'System design, CI/CD pipelines, and infrastructure automation that keep releases fast, repeatable, and predictable.',
-  },
-  {
-    term: 'AI integration',
-    description:
-      'Bringing LLMs and AI-driven features into real products that ship—not demos that stall in a notebook.',
-  },
-  {
-    term: 'Cybersecurity',
-    description: 'Security reviews and hardening so the systems I build stay resilient when it matters.',
-  },
-  {
-    term: 'Technical leadership',
-    description:
-      'Leading engineering teams, mentoring developers, and setting technical direction that scales with the product.',
-  },
-];
+// Home framing of the shared capability areas: concrete, punchy taglines for the
+// "What I do" block. The visible list and the JSON-LD ItemList below both read
+// from this array, so they never drift apart.
+const CAPABILITIES = buildCapabilities({
+  'Web platforms':
+    'Production frontends in React, Angular, and TypeScript, backed by Node.js APIs—shipped end to end, from first commit to deployment.',
+  'Mobile apps': 'Cross-platform mobile applications taken from prototype to the App Store and Google Play.',
+  'Architecture & infrastructure':
+    'System design, CI/CD pipelines, and infrastructure automation that keep releases fast, repeatable, and predictable.',
+  'AI integration':
+    'Bringing LLMs and AI-driven features into real products that ship—not demos that stall in a notebook.',
+  Cybersecurity: 'Security reviews and hardening so the systems I build stay resilient when it matters.',
+  'Technical leadership':
+    'Leading engineering teams, mentoring developers, and setting technical direction that scales with the product.',
+});
 
 const { person } = STRUCTURED_DATA;
 const structuredData = createPageSchema({


### PR DESCRIPTION
## Description

Reuses the "What I do" capability content across the site without creating duplicate-content blocks. The six areas are extracted into a shared single source of truth (`src/data/capabilities.ts`), exposing `CAPABILITY_AREAS` plus a `buildCapabilities()` helper whose `Record<CapabilityArea, string>` type guarantees every page describes all six areas in the same order — so the set can never drift between pages.

Each page frames the same areas in its own words:

- **Home** (`index.astro`): unchanged copy (punchy taglines), now sourced from the shared module; still drives the JSON-LD `ItemList`.
- **About** (`bio.astro`): new `What I do` section with a track-record / experience framing.
- **Contact** (`contact.astro`): the generic "entire technology stack" paragraph is replaced with a `What we can work on` section using short, engagement-oriented service lines.

All three render through the existing `.capabilities` card grid for visual consistency.

## Type of change

- [x] feat — a new feature
- [ ] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)