### PR TITLE
feat(files): restructure files page from table to card layout

### DIFF
--- a/scripts/presentations/validate-and-fix-metadata.sh
+++ b/scripts/presentations/validate-and-fix-metadata.sh
@@ -59,8 +59,8 @@ verify_metadata_csv() {
 
     local first_line
     first_line=$(head -n 1 "$METADATA_CSV")
-    if [[ "$first_line" != "filename,title,subject,keywords" ]]; then
-        log_error "Invalid CSV format. Expected header: filename,title,subject,keywords"
+    if [[ "$first_line" != "filename,title,subject,keywords,description,relatedArticle" ]]; then
+        log_error "Invalid CSV format. Expected header: filename,title,subject,keywords,description,relatedArticle"
         exit 2
     fi
 }

--- a/src/lib/presentations.test.ts
+++ b/src/lib/presentations.test.ts
@@ -40,9 +40,9 @@ describe('formatFileSize', () => {
 
 describe('parsePresentationMetadata', () => {
   const csv = [
-    'filename,title,subject,keywords',
-    'js_01_node_pl,"JavaScript | Wstęp do Node.js - NODE, NVM, NPM…","Node.js","JavaScript, Node.js, NVM, NPM"',
-    'js_02_npm_pl,"JavaScript | NPM - package.json, zależności…","NPM","JavaScript, NPM, package.json"',
+    'filename,title,subject,keywords,description,relatedArticle',
+    'js_01_node_pl,"JavaScript | Wstęp do Node.js - NODE, NVM, NPM…","Node.js","JavaScript, Node.js, NVM, NPM","Intro to Node.js",""',
+    'js_02_npm_pl,"JavaScript | NPM - package.json, zależności…","NPM","JavaScript, NPM, package.json","NPM deep dive","/npm-post/"',
   ].join('\n');
 
   it('maps each filename to its descriptive metadata', () => {
@@ -51,6 +51,8 @@ describe('parsePresentationMetadata', () => {
       title: 'JavaScript | Wstęp do Node.js - NODE, NVM, NPM…',
       subject: 'Node.js',
       keywords: 'JavaScript, Node.js, NVM, NPM',
+      description: 'Intro to Node.js',
+      relatedArticle: '',
     });
   });
 
@@ -58,6 +60,12 @@ describe('parsePresentationMetadata', () => {
     const map = parsePresentationMetadata(csv);
     expect(map.get('js_02_npm_pl')?.title).toBe('JavaScript | NPM - package.json, zależności…');
     expect(map.get('js_02_npm_pl')?.keywords).toBe('JavaScript, NPM, package.json');
+  });
+
+  it('parses description and relatedArticle fields', () => {
+    const map = parsePresentationMetadata(csv);
+    expect(map.get('js_02_npm_pl')?.description).toBe('NPM deep dive');
+    expect(map.get('js_02_npm_pl')?.relatedArticle).toBe('/npm-post/');
   });
 
   it('ignores the header row and blank lines', () => {
@@ -71,7 +79,9 @@ describe('parsePresentationMetadata', () => {
   });
 
   it('unescapes doubled quotes inside a field', () => {
-    const map = parsePresentationMetadata('filename,title,subject,keywords\nx_01_y_pl,"A ""quoted"" title","S","k"');
+    const map = parsePresentationMetadata(
+      'filename,title,subject,keywords,description,relatedArticle\nx_01_y_pl,"A ""quoted"" title","S","k","desc",""',
+    );
     expect(map.get('x_01_y_pl')?.title).toBe('A "quoted" title');
   });
 });

--- a/src/lib/presentations.ts
+++ b/src/lib/presentations.ts
@@ -31,7 +31,13 @@ export const formatFileSize = (bytes: number): string => {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 };
 
-export type PresentationMeta = { title: string; subject: string; keywords: string };
+export type PresentationMeta = {
+  title: string;
+  subject: string;
+  keywords: string;
+  description: string;
+  relatedArticle: string;
+};
 
 // Split a single CSV row into fields, honouring double-quoted fields that may
 // contain commas. A doubled quote ("") inside a quoted field is a literal quote.
@@ -72,7 +78,7 @@ export const parsePresentationMetadata = (csv: string): Map<string, Presentation
   const map = new Map<string, PresentationMeta>();
   const lines = csv.split(/\r?\n/).filter(line => line.trim() !== '');
   for (const line of lines.slice(1)) {
-    const [filename, title, subject, keywords] = parseCsvRow(line);
+    const [filename, title, subject, keywords, description, relatedArticle] = parseCsvRow(line);
     if (!filename) {
       continue;
     }
@@ -80,6 +86,8 @@ export const parsePresentationMetadata = (csv: string): Map<string, Presentation
       title: title ?? '',
       subject: subject ?? '',
       keywords: keywords ?? '',
+      description: description ?? '',
+      relatedArticle: relatedArticle ?? '',
     });
   }
   return map;

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -41,9 +41,9 @@ const readFilesRecursively = (dir: string, baseDir: string): FileNode[] => {
 const nodes = readFilesRecursively(filesDir, filesDir).filter(node => node.extension !== 'csv');
 
 // metadata.csv is the source of truth for each presentation's document metadata
-// (title/subject/keywords) and is kept in sync with the PDFs by the pre-commit
-// validator. Reusing it here gives the public table — and search engines —
-// descriptive titles and context instead of terse filename fragments.
+// and is kept in sync with the PDFs by the pre-commit validator. Reusing it here
+// gives the cards — and search engines — descriptive titles and context instead
+// of terse filename fragments.
 const metadataCsvPath = path.join(filesDir, 'presentations', 'metadata.csv');
 const presentationMeta = fs.existsSync(metadataCsvPath)
   ? parsePresentationMetadata(fs.readFileSync(metadataCsvPath, 'utf8'))

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -92,7 +92,6 @@ const rows = sortedEntries
     const parsed = parseFileName(files[0]?.name ?? '');
     if (!parsed || !files[0]) return null;
     const pdfFile = files.find(f => f.extension.toLowerCase() === 'pdf');
-    const sizeSource = pdfFile ?? files[0];
     // Prefer the descriptive metadata.csv title/subject; fall back to a
     // humanised filename fragment when an entry is missing from the CSV.
     const meta = presentationMeta.get(files[0].name);
@@ -131,7 +130,6 @@ const rows = sortedEntries
       description,
       relatedArticle,
       language: parsed.language,
-      size: formatFileSize(sizeSource.size),
       openHref: pdfFile?.publicURL ?? files[0].publicURL,
       links,
     };

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -100,6 +100,8 @@ const rows = sortedEntries
     const displayTitle = meta?.title || fallbackTitle;
     const topic = meta?.subject || parsed.topic.toUpperCase();
     const keywords = meta?.keywords ?? '';
+    const description = meta?.description ?? '';
+    const relatedArticle = meta?.relatedArticle ?? '';
     const downloadLabel = meta?.subject || fallbackTitle;
     const links = [...files]
       .sort((a, b) => {
@@ -126,6 +128,8 @@ const rows = sortedEntries
       topic,
       title: displayTitle,
       keywords,
+      description,
+      relatedArticle,
       language: parsed.language,
       size: formatFileSize(sizeSource.size),
       openHref: pdfFile?.publicURL ?? files[0].publicURL,
@@ -182,6 +186,7 @@ const structuredData = createPageSchema({
         item: {
           '@type': 'DigitalDocument',
           name: row.title,
+          ...(row.description ? { description: row.description } : {}),
           ...(row.topic ? { about: row.topic } : {}),
           ...(row.keywords ? { keywords: row.keywords } : {}),
           inLanguage: row.language.toLowerCase(),
@@ -205,85 +210,65 @@ const structuredData = createPageSchema({
     <section aria-labelledby="presentations-heading">
       <h2 id="presentations-heading">Presentations</h2>
       <p class="presentations-intro">
-        Slides from my technical talks and workshops on Node.js, JavaScript, and modern web development. Each
-        presentation opens or downloads as a PDF — titles link straight to the document.
+        Slides from my technical talks and workshops on Node.js, JavaScript, and modern web development.
       </p>
-      <div class="table-scroll" tabindex="0">
-        <table class="presentations-table" data-presentations>
-          <caption class="visually-hidden">
-            Technical presentations by Dawid Ryłko, each available to view or download as a PDF.
-          </caption>
-          <colgroup>
-            <col class="col-w-5" />
-            <col class="col-w-35" />
-            <col class="col-w-20" />
-            <col class="col-w-10" />
-            <col class="col-w-10" />
-            <col class="col-w-20" />
-          </colgroup>
-          <thead>
-            <tr>
-              <th scope="col">#</th>
-              <th scope="col">Presentation</th>
-              <th scope="col">Topic</th>
-              <th scope="col">Lang</th>
-              <th scope="col">Size</th>
-              <th scope="col">Download</th>
-            </tr>
-          </thead>
-          <tbody>
-            {
-              rows.map(row => (
-                <tr>
-                  <td>{row.index}</td>
-                  <td class="presentation-cell">
-                    <a
-                      class="presentation-title"
-                      href={row.openHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label={`Open ${row.title} (PDF) in a new tab`}
-                    >
-                      {row.title}
-                    </a>
-                    {row.keywords && <span class="presentation-keywords">{row.keywords}</span>}
-                  </td>
-                  <td>{row.topic}</td>
-                  <td>{row.language}</td>
-                  <td>{row.size}</td>
-                  <td>
-                    <div class="file-actions">
-                      {row.links.map(link =>
-                        link.action === 'open' ? (
-                          <a
-                            class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
-                            href={link.href}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            aria-label={`Open ${link.title} ${link.type} in new tab`}
-                            title={`Open ${link.type} in new tab (${link.size})`}
-                          >
-                            {link.icon}
-                          </a>
-                        ) : (
-                          <a
-                            class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
-                            href={link.href}
-                            download={link.download}
-                            aria-label={`Download ${link.title} as ${link.type}`}
-                            title={`Download ${link.type} (${link.size})`}
-                          >
-                            {link.icon}
-                          </a>
-                        ),
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              ))
-            }
-          </tbody>
-        </table>
+      <div class="presentations-grid" data-presentations>
+        {
+          rows.map(row => (
+            <article class="presentation-card">
+              <h3 class="presentation-card-title">
+                <a href={row.openHref} target="_blank" rel="noopener noreferrer">
+                  {row.title}
+                </a>
+              </h3>
+              <dl class="presentation-details">
+                <dt>Topic</dt>
+                <dd>{row.topic}</dd>
+                <dt>Language</dt>
+                <dd>{row.language}</dd>
+                {row.description && (
+                  <>
+                    <dt>Description</dt>
+                    <dd class="presentation-description">{row.description}</dd>
+                  </>
+                )}
+              </dl>
+              <div class="presentation-card-footer">
+                <div class="file-actions">
+                  {row.links.map(link =>
+                    link.action === 'open' ? (
+                      <a
+                        class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`Open ${link.title} ${link.type} in new tab`}
+                        title={`Open ${link.type} in new tab (${link.size})`}
+                      >
+                        {link.icon} {link.type}
+                      </a>
+                    ) : (
+                      <a
+                        class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
+                        href={link.href}
+                        download={link.download}
+                        aria-label={`Download ${link.title} as ${link.type}`}
+                        title={`Download ${link.type} (${link.size})`}
+                      >
+                        {link.icon} {link.type} ({link.size})
+                      </a>
+                    ),
+                  )}
+                </div>
+                {row.relatedArticle && (
+                  <a class="presentation-related" href={row.relatedArticle}>
+                    Related article →
+                  </a>
+                )}
+              </div>
+            </article>
+          ))
+        }
       </div>
     </section>
   </main>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -446,43 +446,90 @@ table tr:last-child td {
   border: 0;
 }
 
-/* Files page: short lead-in above the presentations table. */
+/* Files page: short lead-in above the presentations grid. */
 .presentations-intro {
   max-width: 60ch;
 }
 
-/* The presentation title cell carries long descriptive text (the document title
-   plus a keyword line); let it wrap instead of inheriting the table-wide
-   white-space: nowrap, which would force a wide horizontal scroll. */
-.presentations-table .presentation-cell {
-  white-space: normal;
+.presentations-grid {
+  display: grid;
+  gap: var(--spacing-6);
 }
 
-.presentation-title {
-  font-weight: 600;
+.presentation-card {
+  padding: var(--spacing-6);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-pill);
 }
 
-.presentation-keywords {
-  display: block;
-  margin-top: var(--spacing-1);
+.presentation-card-title {
+  margin-top: 0;
+  margin-bottom: var(--spacing-4);
+  font-size: var(--fontSize-3);
+}
+
+.presentation-details {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--spacing-1) var(--spacing-4);
+  margin: 0 0 var(--spacing-4);
+  font-size: var(--fontSize-1);
+}
+
+.presentation-details dt {
   color: var(--color-text-light);
+  font-family: var(--font-heading);
+  font-weight: var(--fontWeight-bold);
   font-size: var(--fontSize-0);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
-/* Download actions cell on the files page: keep icons in a row. */
+.presentation-details dd {
+  margin: 0;
+}
+
+.presentation-description {
+  grid-column: 1 / -1;
+  color: var(--color-text-light);
+}
+
+.presentation-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding-top: var(--spacing-4);
+  border-top: 1px solid var(--color-accent);
+}
+
+/* Download actions on the files page: keep icons in a row. */
 .file-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--spacing-2);
+  gap: var(--spacing-3);
+}
+
+.file-link {
+  font-size: var(--fontSize-0);
+  white-space: nowrap;
+}
+
+.presentation-related {
+  font-family: var(--font-heading);
+  font-size: var(--fontSize-0);
+  font-weight: var(--fontWeight-bold);
 }
 
 /* Files page: Keynote/PowerPoint download variants are hidden until the
-   cmd/ctrl+shift+. shortcut adds .show-hidden-variants to the table. */
-.presentations-table .file-link.is-hidden-variant {
+   cmd/ctrl+shift+. shortcut adds .show-hidden-variants to the grid. */
+.presentations-grid .file-link.is-hidden-variant {
   display: none;
 }
 
-.presentations-table.show-hidden-variants .file-link.is-hidden-variant {
+.presentations-grid.show-hidden-variants .file-link.is-hidden-variant {
   display: inline;
 }
 

--- a/static/files/presentations/metadata.csv
+++ b/static/files/presentations/metadata.csv
@@ -1,4 +1,4 @@
-filename,title,subject,keywords
-js_01_node_pl,"JavaScript | Wstęp do Node.js - NODE, NVM, NPM…","Node.js","JavaScript, Node.js, NVM, NPM"
-js_02_npm_pl,"JavaScript | NPM - package.json, zależności, SemVer, package-lock.json…","NPM","JavaScript, NPM, package.json, SemVer, dependencies"
-js_03_npm_pl,"JavaScript | NPM - automatyzacja, npx, narzędzia…","NPM","JavaScript, NPM, npx, automation, tools"
+filename,title,subject,keywords,description,relatedArticle
+js_01_node_pl,"JavaScript | Wstęp do Node.js - NODE, NVM, NPM…","Node.js","JavaScript, Node.js, NVM, NPM","Introduction to Node.js runtime: installation via NVM, first steps with the REPL, and an overview of the NPM ecosystem.",""
+js_02_npm_pl,"JavaScript | NPM - package.json, zależności, SemVer, package-lock.json…","NPM","JavaScript, NPM, package.json, SemVer, dependencies","Deep dive into NPM fundamentals: package.json structure, dependency management, Semantic Versioning, and the role of package-lock.json.",""
+js_03_npm_pl,"JavaScript | NPM - automatyzacja, npx, narzędzia…","NPM","JavaScript, NPM, npx, automation, tools","Automating workflows with NPM scripts, running packages on-the-fly with npx, and essential tooling for modern JavaScript projects.",""


### PR DESCRIPTION
## Description

Restructure the `/files/` page from a dense table into a card-based layout. Each presentation now displays:

- **Title** — linked to the PDF
- **Topic** — subject area (e.g. Node.js, NPM)
- **Language** — presentation language
- **Description** — short summary of what the presentation covers
- **Download** — open/download actions for PDF (and hidden Keynote/PowerPoint variants via cmd/ctrl+shift+.)
- **Related article** — optional link to a blog post (field added to metadata.csv, currently empty for all presentations)

The `metadata.csv` schema is extended with `description` and `relatedArticle` columns. The pre-commit validator, parser, tests, CSS, and JSON-LD structured data are all updated to match.

## Type of change

- [x] feat — a new feature
- [ ] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)