### PR TITLE
feat(i18n): formalize and guard the PL/EN language strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,9 @@ jobs:
       - name: Verify SEO / structured-data contract
         run: node scripts/ci/check-seo-meta.mjs
 
+      - name: Verify PL/EN language strategy contract
+        run: node scripts/ci/check-lang-attributes.mjs
+
       - name: Verify SEO title/description lengths
         run: node scripts/ci/check-seo-lengths.mjs
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -63,6 +63,21 @@ pnpm build
 node scripts/ci/check-bundle-budget.mjs
 ```
 
+## `check-lang-attributes.mjs`
+
+Locks the PL/EN language strategy (mirrored in `src/lib/i18n.ts`) on the rendered
+pages: every indexable page declares a supported `<html lang>` (en, pl) with an
+agreeing `og:locale`, the English shell routes (`/`, `/bio/`, `/contact/`,
+`/setup/`, `/metadata/`, `/files/`) stay `lang=en` while the blog, post and tag
+routes stay `lang=pl`, and indexable pages self-reference their language via
+`hreflang` + `x-default` (noindex pages emit none). Runs in the `build-contract`
+job.
+
+```bash
+pnpm build
+node scripts/ci/check-lang-attributes.mjs
+```
+
 ## `check-no-ai-attribution.mjs`
 
 Enforces the no-AI-attribution rule from `CLAUDE.md`: fails if a commit message

--- a/scripts/ci/check-lang-attributes.mjs
+++ b/scripts/ci/check-lang-attributes.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Language-strategy contract for the Astro build (dist/).
+ *
+ * The site is bilingual at the site level, monolingual per URL: an English
+ * "shell" (home, /bio/, /contact/, /setup/, /metadata/, /files/) wraps a Polish
+ * content zone (/blog/, individual posts, /tags/). This check locks that split
+ * so the language signals can never silently drift apart:
+ *
+ *   - every indexable page declares a <html lang> that is one of the supported
+ *     languages (en, pl)
+ *   - <meta property="og:locale"> agrees with that lang (en→en_US, pl→pl_PL)
+ *   - the known English shell routes stay lang=en; the blog, post and tag routes
+ *     stay lang=pl (post pages are detected by og:type=article)
+ *   - indexable pages self-reference their language via hreflang and an
+ *     x-default, both pointing at the page's own canonical URL
+ *   - noindex pages (e.g. 404) emit no hreflang at all, mirroring the canonical
+ *     rule (an alternate would point at a non-200 URL, which SEO audits flag)
+ *
+ * Redirect stubs (meta-refresh pages such as /resume/) are skipped. Zero
+ * dependencies; runs against the built output, it does NOT rebuild. Exits
+ * non-zero listing every page that fails.
+ */
+
+import { readFile, readdir, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative, sep } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : resolve(__dirname, '../../dist');
+
+// Kept in sync with src/lib/i18n.ts (this gate has zero deps, so the mapping is
+// duplicated rather than imported from the TypeScript source).
+const OG_LOCALES = { en: 'en_US', pl: 'pl_PL' };
+const SUPPORTED_LANGS = Object.keys(OG_LOCALES);
+
+// Routes that make up the English shell. Everything else that is indexable is
+// the Polish content zone (blog listings, posts, tag archive).
+const ENGLISH_ROUTES = new Set(['/', '/bio/', '/contact/', '/setup/', '/metadata/', '/files/']);
+
+const problems = [];
+const fail = msg => problems.push(msg);
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Recursively collect every .html file under dir. */
+async function collectHtml(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return collectHtml(full);
+      return entry.name.endsWith('.html') ? [full] : [];
+    }),
+  );
+  return files.flat();
+}
+
+/** dist-relative file path → site pathname (e.g. blog/2/index.html → /blog/2/). */
+function toPathname(rel) {
+  const url = rel
+    .split(sep)
+    .join('/')
+    .replace(/index\.html$/, '')
+    .replace(/\.html$/, '');
+  return `/${url}`.replace(/\/{2,}/g, '/');
+}
+
+/** Expected language for a route, or null when the route is not classified. */
+function expectedLang(pathname, isArticle) {
+  if (ENGLISH_ROUTES.has(pathname)) return 'en';
+  if (pathname === '/blog/' || /^\/blog\/\d+\/$/.test(pathname)) return 'pl';
+  if (pathname.startsWith('/tags/')) return 'pl';
+  if (isArticle) return 'pl';
+  return null;
+}
+
+function checkPage(rel, html) {
+  // Redirect stubs have no real <head> chrome — skip them.
+  if (/http-equiv="refresh"/i.test(html)) return;
+
+  const pathname = toPathname(rel);
+  const isNoindex = /<meta[^>]*name="robots"[^>]*content="[^"]*noindex/i.test(html);
+  const isArticle = /<meta[^>]*property="og:type"[^>]*content="article"/.test(html);
+
+  const langMatch = html.match(/<html[^>]*\blang="([^"]*)"/i);
+  const lang = langMatch?.[1]?.trim();
+  if (!lang) {
+    fail(`${rel}: missing <html lang> attribute`);
+    return;
+  }
+  if (!SUPPORTED_LANGS.includes(lang)) {
+    fail(`${rel}: <html lang="${lang}"> is not a supported language (${SUPPORTED_LANGS.join(', ')})`);
+    return;
+  }
+
+  // og:locale must agree with the document language.
+  const ogLocale = html.match(/<meta[^>]*property="og:locale"[^>]*content="([^"]*)"/)?.[1];
+  if (ogLocale !== OG_LOCALES[lang]) {
+    fail(`${rel}: og:locale "${ogLocale ?? ''}" does not match lang "${lang}" (expected ${OG_LOCALES[lang]})`);
+  }
+
+  // The English shell and the Polish content zone must not swap languages.
+  const wanted = expectedLang(pathname, isArticle);
+  if (wanted && wanted !== lang) {
+    fail(`${rel}: expected lang="${wanted}" for this route, found "${lang}"`);
+  }
+
+  // hreflang: indexable pages self-reference their language + x-default; noindex
+  // pages must carry none (an alternate would advertise a non-200 URL).
+  const alternates = [...html.matchAll(/<link[^>]*rel="alternate"[^>]*hreflang="([^"]*)"[^>]*href="([^"]*)"/g)].map(
+    m => ({ hreflang: m[1], href: m[2] }),
+  );
+  if (isNoindex) {
+    if (alternates.length > 0) fail(`${rel}: noindex page must not emit hreflang alternates`);
+    return;
+  }
+
+  const canonical = html.match(/<link[^>]*rel="canonical"[^>]*href="([^"]*)"/)?.[1];
+  const self = alternates.find(a => a.hreflang === lang);
+  const xDefault = alternates.find(a => a.hreflang === 'x-default');
+  if (!self) fail(`${rel}: missing self-referencing hreflang="${lang}"`);
+  else if (canonical && self.href !== canonical) {
+    fail(`${rel}: hreflang="${lang}" href "${self.href}" does not match canonical "${canonical}"`);
+  }
+  if (!xDefault) fail(`${rel}: missing hreflang="x-default"`);
+  else if (canonical && xDefault.href !== canonical) {
+    fail(`${rel}: hreflang="x-default" href "${xDefault.href}" does not match canonical "${canonical}"`);
+  }
+}
+
+async function main() {
+  if (!(await exists(DIST_DIR))) {
+    console.error(`Build output not found at ${DIST_DIR}. Run "pnpm build" first.`);
+    process.exit(1);
+  }
+
+  const pages = await collectHtml(DIST_DIR);
+  if (pages.length === 0) fail('no HTML pages found in dist');
+
+  for (const page of pages) {
+    const rel = relative(DIST_DIR, page);
+    checkPage(rel, await readFile(page, 'utf8'));
+  }
+
+  console.log('Language-strategy contract (dist/)\n');
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(`  ✗ ${problem}`);
+    console.error(`\nLanguage contract failed: ${problems.length} problem(s).`);
+    process.exit(1);
+  }
+  console.log(`  ✓ ${pages.length} page(s): lang + og:locale consistent; hreflang self/x-default present.`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -1,6 +1,7 @@
 ---
 import { SITE_METADATA } from '../data/site-metadata';
 import { resolveMetaTitle, resolveMetaDescription } from '../lib/seo';
+import { DEFAULT_LANG, toOgLocale } from '../lib/i18n';
 
 // Port of the Gatsby <Seo> component (src/components/seo.tsx): title, description,
 // canonical/OG url, Open Graph and Twitter Card meta. The <html lang> attribute
@@ -40,9 +41,8 @@ const {
 // Square brand icon emitted by the PWA manifest; OG/Twitter fallback image.
 const DEFAULT_OG_IMAGE = '/icons/icon-512x512.png';
 const DEFAULT_OG_IMAGE_SIZE = 512;
-const OG_LOCALES: Record<string, string> = { en: 'en_US', pl: 'pl_PL' };
 
-const metaLang = lang ?? SITE_METADATA.lang;
+const metaLang = lang ?? DEFAULT_LANG;
 const siteTitle = SITE_METADATA.title;
 const author = SITE_METADATA.author;
 
@@ -94,7 +94,7 @@ const robots = noIndex
 {ogImageWidth && <meta property="og:image:width" content={String(ogImageWidth)} />}
 {ogImageHeight && <meta property="og:image:height" content={String(ogImageHeight)} />}
 <meta property="og:site_name" content={siteTitle} />
-<meta property="og:locale" content={OG_LOCALES[metaLang] ?? metaLang} />
+<meta property="og:locale" content={toOgLocale(metaLang)} />
 
 {
   article && (

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -28,6 +28,7 @@ import JsonLd from '../components/JsonLd.astro';
 import { SITE_METADATA } from '../data/site-metadata';
 import { STRUCTURED_DATA } from '../data/structured-data';
 import { GTAG } from '../data/gtag';
+import { DEFAULT_LANG } from '../lib/i18n';
 import type { NavLink } from '../types';
 
 // Port of src/components/layout.tsx — the chrome shared by every page (header
@@ -66,7 +67,7 @@ const {
   lang,
 } = Astro.props;
 
-const metaLang = lang ?? SITE_METADATA.lang;
+const metaLang = lang ?? DEFAULT_LANG;
 const pathname = Astro.url.pathname;
 const isRootPath = pathname === '/';
 const canonical = new URL(pathname, Astro.site).href;
@@ -88,6 +89,15 @@ const { website } = STRUCTURED_DATA;
         point at a non-200 URL, which SEO audits flag. */
     }
     {!noIndex && <link rel="canonical" href={canonical} />}
+    {
+      /* hreflang declares each URL's language to search engines. Every page is
+        monolingual (English shell or Polish content) with no translated twin, so
+        the page self-references its own language and doubles as x-default. Like
+        the canonical, it is skipped on noindex pages so it never points at a
+        non-200 URL. */
+    }
+    {!noIndex && <link rel="alternate" hreflang={metaLang} href={canonical} />}
+    {!noIndex && <link rel="alternate" hreflang="x-default" href={canonical} />}
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#005b99" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { SITE_METADATA } from '../data/site-metadata';
+import { DEFAULT_LANG, CONTENT_LANG, SUPPORTED_LANGS, OG_LOCALES, isSupportedLang, toOgLocale } from './i18n';
+
+describe('language constants', () => {
+  it('uses the site-metadata language as the shell default', () => {
+    expect(DEFAULT_LANG).toBe(SITE_METADATA.lang);
+  });
+
+  it('ships English shell and Polish content as distinct languages', () => {
+    expect(DEFAULT_LANG).toBe('en');
+    expect(CONTENT_LANG).toBe('pl');
+    expect(DEFAULT_LANG).not.toBe(CONTENT_LANG);
+  });
+
+  it('lists every supported language with the shell first', () => {
+    expect(SUPPORTED_LANGS).toEqual(['en', 'pl']);
+  });
+
+  it('maps an Open Graph locale for every supported language', () => {
+    for (const lang of SUPPORTED_LANGS) {
+      expect(OG_LOCALES[lang]).toMatch(/^[a-z]{2}_[A-Z]{2}$/);
+    }
+  });
+});
+
+describe('isSupportedLang', () => {
+  it('accepts the languages the site ships', () => {
+    expect(isSupportedLang('en')).toBe(true);
+    expect(isSupportedLang('pl')).toBe(true);
+  });
+
+  it('rejects languages the site does not ship', () => {
+    expect(isSupportedLang('de')).toBe(false);
+    expect(isSupportedLang('')).toBe(false);
+  });
+});
+
+describe('toOgLocale', () => {
+  it('maps a BCP-47 tag to its Open Graph locale', () => {
+    expect(toOgLocale('en')).toBe('en_US');
+    expect(toOgLocale('pl')).toBe('pl_PL');
+  });
+
+  it('falls back to the raw tag for unmapped languages so the tag is never empty', () => {
+    expect(toOgLocale('fr')).toBe('fr');
+  });
+});

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,44 @@
+import { SITE_METADATA } from '../data/site-metadata';
+
+/**
+ * Single source of truth for the site's PL/EN language strategy.
+ *
+ * The site is bilingual at the *site* level, monolingual per URL: an English
+ * "shell" (home, /bio/, /contact/, /setup/, /metadata/, /files/, 404) wraps a
+ * Polish content zone (the blog at /blog/, individual posts, and /tags/). Each
+ * page therefore declares exactly one language — `<html lang>` (set by the
+ * layout from each page's `lang` prop), `og:locale`, JSON-LD `inLanguage` and
+ * the hreflang annotations all agree on it.
+ *
+ * `DEFAULT_LANG` is the shell language used when a page passes no `lang`; the
+ * Polish content pages opt in explicitly via `CONTENT_LANG`. Keeping these — and
+ * the BCP-47 → Open Graph locale mapping — in one module stops the language
+ * codes drifting apart across the layout, the SEO head and the build contract.
+ */
+
+/** Shell language: used by every page that does not opt into Polish. */
+export const DEFAULT_LANG = SITE_METADATA.lang;
+
+/** Content-zone language: the blog, individual posts and the tag archive. */
+export const CONTENT_LANG = 'pl';
+
+/** Every language the site ships, in priority order (shell first). */
+export const SUPPORTED_LANGS = [DEFAULT_LANG, CONTENT_LANG] as const;
+
+export type SupportedLang = (typeof SUPPORTED_LANGS)[number];
+
+/** BCP-47 language tag → Open Graph `og:locale` (language_TERRITORY). */
+export const OG_LOCALES: Record<string, string> = {
+  en: 'en_US',
+  pl: 'pl_PL',
+};
+
+/** Whether a language code is one the site actually ships. */
+export const isSupportedLang = (lang: string): lang is SupportedLang =>
+  (SUPPORTED_LANGS as readonly string[]).includes(lang);
+
+/**
+ * Open Graph locale for a page's language. Falls back to the raw tag for any
+ * value missing from the map so the meta tag is never emitted empty.
+ */
+export const toOgLocale = (lang: string): string => OG_LOCALES[lang] ?? lang;

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -17,6 +17,7 @@ import { countWords, readingTimeMinutes } from '../lib/reading-time';
 import { plPlural } from '../lib/pl-plural';
 import { relatedPosts } from '../lib/related-posts';
 import { buildTocTree } from '../lib/toc';
+import { CONTENT_LANG } from '../lib/i18n';
 
 export async function getStaticPaths() {
   // Replicates Gatsby's createPages exactly: posts ordered by frontmatter date
@@ -121,7 +122,7 @@ const structuredData = {
   publishedTime={publishedTime}
   modifiedTime={modifiedTime}
   tags={tags}
-  lang="pl"
+  lang={CONTENT_LANG}
 >
   <JsonLd data={structuredData} />
   <article class="blog-post">

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -11,6 +11,7 @@ import { STRUCTURED_DATA } from '../../data/structured-data';
 import { excerpt } from '../../lib/excerpt';
 import { getBlogPosts, POSTS_PER_PAGE } from '../../lib/blog';
 import { toISODate } from '../../lib/date';
+import { CONTENT_LANG } from '../../lib/i18n';
 
 const PAGE_METADATA = {
   title: 'Blog 🇵🇱',
@@ -93,7 +94,12 @@ const structuredData = {
 };
 ---
 
-<PageLayout breadcrumbTitle={breadcrumbTitle} title={pageTitle} description={PAGE_METADATA.description} lang="pl">
+<PageLayout
+  breadcrumbTitle={breadcrumbTitle}
+  title={pageTitle}
+  description={PAGE_METADATA.description}
+  lang={CONTENT_LANG}
+>
   <JsonLd data={structuredData} />
   <header>
     <h1>{PAGE_METADATA.title}</h1>

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -7,6 +7,7 @@ import { SITE_METADATA } from '../../data/site-metadata';
 import { createPageSchema } from '../../lib/page-metadata';
 import { getTags, postCountLabel, describeTagPage, type TagInfo } from '../../lib/tags';
 import { toISODate } from '../../lib/date';
+import { CONTENT_LANG } from '../../lib/i18n';
 
 export const getStaticPaths = (async () => {
   const tags = await getTags();
@@ -53,7 +54,7 @@ const structuredData = createPageSchema({
   ]}
   title={title}
   description={description}
-  lang="pl"
+  lang={CONTENT_LANG}
 >
   <JsonLd data={structuredData} />
   <header>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -4,6 +4,7 @@ import JsonLd from '../../components/JsonLd.astro';
 import { SITE_METADATA } from '../../data/site-metadata';
 import { createPageSchema } from '../../lib/page-metadata';
 import { getTags, tagCountLabel } from '../../lib/tags';
+import { CONTENT_LANG } from '../../lib/i18n';
 import type { PageMetadata } from '../../types';
 
 const tags = await getTags();
@@ -41,7 +42,7 @@ const structuredData = createPageSchema({
   breadcrumbParents={[{ name: 'Blog 🇵🇱', url: '/blog/' }]}
   title={PAGE_METADATA.title}
   description={PAGE_METADATA.description}
-  lang="pl"
+  lang={CONTENT_LANG}
 >
   <JsonLd data={structuredData} />
   <header>


### PR DESCRIPTION
## Description

The site is bilingual at the site level but monolingual per URL: an English "shell" (home, `/bio/`, `/contact/`, `/setup/`, `/metadata/`, `/files/`) wraps a Polish content zone (`/blog/`, individual posts, `/tags/`). That split already drove `<html lang>`, `og:locale` and JSON-LD `inLanguage`, but the language codes were scattered as literals across the layout, the SEO head and four page templates, there was **no machine-readable hreflang**, and nothing guarded the contract against regression.

This PR formalizes and locks the strategy without changing the intentional English-shell default:

- **`src/lib/i18n.ts`** — one source of truth: the shell default language (`= SITE_METADATA.lang`, kept `en`), the content-zone language, the supported-language list and the BCP-47 to `og:locale` map, with the rationale documented in one place.
- **`Seo.astro`** consumes `toOgLocale()` from the lib (the inline locale map is gone); the four Polish content pages opt in via the shared `CONTENT_LANG` constant instead of a `"pl"` literal. No behaviour change — `og:locale` and `<html lang>` render exactly as before.
- **hreflang** — every indexable page now self-references its language via `<link rel="alternate" hreflang>` plus an `x-default`, both pointing at its own canonical. Skipped on `noindex` pages (e.g. 404), mirroring the existing canonical rule so no alternate ever advertises a non-200 URL.
- **`scripts/ci/check-lang-attributes.mjs`** (wired into the `build-contract` job) locks the `lang` / `og:locale` / hreflang contract on `dist/`: English routes stay `en`, blog/post/tag routes stay `pl` (posts detected by `og:type=article`), and the signals must agree. Plus unit tests for `i18n.ts`.

Verified locally on the build: 75 pages pass the new language contract, the SEO/structured-data and build-output contracts still pass, and the intentional `lang="en"` default in `PageLayout`/`Seo` is untouched (per `CLAUDE.md`). Post URLs are unchanged.

## Type of change

- [x] feat — a new feature
- [ ] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)