### PR TITLE
refactor(files): revert card layout to table with description and article columns

### DIFF
--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -42,7 +42,7 @@ const nodes = readFilesRecursively(filesDir, filesDir).filter(node => node.exten
 
 // metadata.csv is the source of truth for each presentation's document metadata
 // and is kept in sync with the PDFs by the pre-commit validator. Reusing it here
-// gives the cards — and search engines — descriptive titles and context instead
+// gives the table — and search engines — descriptive titles and context instead
 // of terse filename fragments.
 const metadataCsvPath = path.join(filesDir, 'presentations', 'metadata.csv');
 const presentationMeta = fs.existsSync(metadataCsvPath)
@@ -92,6 +92,7 @@ const rows = sortedEntries
     const parsed = parseFileName(files[0]?.name ?? '');
     if (!parsed || !files[0]) return null;
     const pdfFile = files.find(f => f.extension.toLowerCase() === 'pdf');
+    const sizeSource = pdfFile ?? files[0];
     // Prefer the descriptive metadata.csv title/subject; fall back to a
     // humanised filename fragment when an entry is missing from the CSV.
     const meta = presentationMeta.get(files[0].name);
@@ -130,6 +131,7 @@ const rows = sortedEntries
       description,
       relatedArticle,
       language: parsed.language,
+      size: formatFileSize(sizeSource.size),
       openHref: pdfFile?.publicURL ?? files[0].publicURL,
       links,
     };
@@ -208,65 +210,88 @@ const structuredData = createPageSchema({
     <section aria-labelledby="presentations-heading">
       <h2 id="presentations-heading">Presentations</h2>
       <p class="presentations-intro">
-        Slides from my technical talks and workshops on Node.js, JavaScript, and modern web development.
+        Slides from my technical talks and workshops on Node.js, JavaScript, and modern web development. Each
+        presentation opens or downloads as a PDF — titles link straight to the document.
       </p>
-      <div class="presentations-grid" data-presentations>
-        {
-          rows.map(row => (
-            <article class="presentation-card">
-              <h3 class="presentation-card-title">
-                <a href={row.openHref} target="_blank" rel="noopener noreferrer">
-                  {row.title}
-                </a>
-              </h3>
-              <dl class="presentation-details">
-                <dt>Topic</dt>
-                <dd>{row.topic}</dd>
-                <dt>Language</dt>
-                <dd>{row.language}</dd>
-                {row.description && (
-                  <>
-                    <dt>Description</dt>
-                    <dd class="presentation-description">{row.description}</dd>
-                  </>
-                )}
-              </dl>
-              <div class="presentation-card-footer">
-                <div class="file-actions">
-                  {row.links.map(link =>
-                    link.action === 'open' ? (
-                      <a
-                        class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
-                        href={link.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`Open ${link.title} ${link.type} in new tab`}
-                        title={`Open ${link.type} in new tab (${link.size})`}
-                      >
-                        {link.icon} {link.type}
+      <div class="table-scroll" tabindex="0">
+        <table class="presentations-table" data-presentations>
+          <caption class="visually-hidden">
+            Technical presentations by Dawid Ryłko, each available to view or download as a PDF.
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Presentation</th>
+              <th scope="col">Topic</th>
+              <th scope="col">Lang</th>
+              <th scope="col">Size</th>
+              <th scope="col">Download</th>
+              <th scope="col">Article</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              rows.map(row => (
+                <tr>
+                  <td>{row.index}</td>
+                  <td class="presentation-cell">
+                    <a
+                      class="presentation-title"
+                      href={row.openHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Open ${row.title} (PDF) in a new tab`}
+                    >
+                      {row.title}
+                    </a>
+                    {row.description && <span class="presentation-description">{row.description}</span>}
+                    {row.keywords && <span class="presentation-keywords">{row.keywords}</span>}
+                  </td>
+                  <td>{row.topic}</td>
+                  <td>{row.language}</td>
+                  <td>{row.size}</td>
+                  <td>
+                    <div class="file-actions">
+                      {row.links.map(link =>
+                        link.action === 'open' ? (
+                          <a
+                            class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
+                            href={link.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`Open ${link.title} ${link.type} in new tab`}
+                            title={`Open ${link.type} in new tab (${link.size})`}
+                          >
+                            {link.icon}
+                          </a>
+                        ) : (
+                          <a
+                            class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
+                            href={link.href}
+                            download={link.download}
+                            aria-label={`Download ${link.title} as ${link.type}`}
+                            title={`Download ${link.type} (${link.size})`}
+                          >
+                            {link.icon}
+                          </a>
+                        ),
+                      )}
+                    </div>
+                  </td>
+                  <td>
+                    {row.relatedArticle ? (
+                      <a href={row.relatedArticle} class="presentation-article-link">
+                        →
                       </a>
                     ) : (
-                      <a
-                        class:list={['file-link', { 'is-hidden-variant': link.hidden }]}
-                        href={link.href}
-                        download={link.download}
-                        aria-label={`Download ${link.title} as ${link.type}`}
-                        title={`Download ${link.type} (${link.size})`}
-                      >
-                        {link.icon} {link.type} ({link.size})
-                      </a>
-                    ),
-                  )}
-                </div>
-                {row.relatedArticle && (
-                  <a class="presentation-related" href={row.relatedArticle}>
-                    Related article →
-                  </a>
-                )}
-              </div>
-            </article>
-          ))
-        }
+                      <span class="presentation-no-article">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
       </div>
     </section>
   </main>

--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -41,9 +41,9 @@ const readFilesRecursively = (dir: string, baseDir: string): FileNode[] => {
 const nodes = readFilesRecursively(filesDir, filesDir).filter(node => node.extension !== 'csv');
 
 // metadata.csv is the source of truth for each presentation's document metadata
-// and is kept in sync with the PDFs by the pre-commit validator. Reusing it here
-// gives the table — and search engines — descriptive titles and context instead
-// of terse filename fragments.
+// and is kept in sync with the PDFs by the pre-commit validator. Reusing it
+// here gives the table — and search engines — descriptive titles and context
+// instead of terse filename fragments.
 const metadataCsvPath = path.join(filesDir, 'presentations', 'metadata.csv');
 const presentationMeta = fs.existsSync(metadataCsvPath)
   ? parsePresentationMetadata(fs.readFileSync(metadataCsvPath, 'utf8'))

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -446,90 +446,59 @@ table tr:last-child td {
   border: 0;
 }
 
-/* Files page: short lead-in above the presentations grid. */
+/* Files page: short lead-in above the presentations table. */
 .presentations-intro {
   max-width: 60ch;
 }
 
-.presentations-grid {
-  display: grid;
-  gap: var(--spacing-6);
+/* The presentation title cell carries long descriptive text (the document title
+   plus description and keyword lines); let it wrap instead of inheriting the
+   table-wide white-space: nowrap, which would force a wide horizontal scroll. */
+.presentations-table .presentation-cell {
+  white-space: normal;
 }
 
-.presentation-card {
-  padding: var(--spacing-6);
-  border: 1px solid var(--color-accent);
-  border-radius: var(--radius-pill);
-}
-
-.presentation-card-title {
-  margin-top: 0;
-  margin-bottom: var(--spacing-4);
-  font-size: var(--fontSize-3);
-}
-
-.presentation-details {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: var(--spacing-1) var(--spacing-4);
-  margin: 0 0 var(--spacing-4);
-  font-size: var(--fontSize-1);
-}
-
-.presentation-details dt {
-  color: var(--color-text-light);
-  font-family: var(--font-heading);
-  font-weight: var(--fontWeight-bold);
-  font-size: var(--fontSize-0);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.presentation-details dd {
-  margin: 0;
+.presentation-title {
+  font-weight: 600;
 }
 
 .presentation-description {
-  grid-column: 1 / -1;
+  display: block;
+  margin-top: var(--spacing-1);
   color: var(--color-text-light);
+  font-size: var(--fontSize-0);
 }
 
-.presentation-card-footer {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-3);
-  padding-top: var(--spacing-4);
-  border-top: 1px solid var(--color-accent);
+.presentation-keywords {
+  display: block;
+  margin-top: var(--spacing-1);
+  color: var(--color-text-light);
+  font-size: var(--fontSize-0);
+  font-style: italic;
 }
 
-/* Download actions on the files page: keep icons in a row. */
+/* Download actions cell on the files page: keep icons in a row. */
 .file-actions {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: var(--spacing-3);
+  gap: var(--spacing-2);
 }
 
-.file-link {
-  font-size: var(--fontSize-0);
-  white-space: nowrap;
-}
-
-.presentation-related {
-  font-family: var(--font-heading);
-  font-size: var(--fontSize-0);
+.presentation-article-link {
   font-weight: var(--fontWeight-bold);
 }
 
+.presentation-no-article {
+  color: var(--color-text-light);
+}
+
 /* Files page: Keynote/PowerPoint download variants are hidden until the
-   cmd/ctrl+shift+. shortcut adds .show-hidden-variants to the grid. */
-.presentations-grid .file-link.is-hidden-variant {
+   cmd/ctrl+shift+. shortcut adds .show-hidden-variants to the table. */
+.presentations-table .file-link.is-hidden-variant {
   display: none;
 }
 
-.presentations-grid.show-hidden-variants .file-link.is-hidden-variant {
+.presentations-table.show-hidden-variants .file-link.is-hidden-variant {
   display: inline;
 }
 


### PR DESCRIPTION
## Description

Revert the `/files/` page from the card-based layout (#451) back to a table, while keeping the new data fields introduced in that PR. The table now has columns:

- **#** — row number
- **Presentation** — title (link to PDF), description, and keywords
- **Topic** — subject area
- **Lang** — language
- **Size** — PDF file size
- **Download** — open/download action icons
- **Article** — link to related blog post (or dash when none)

Description and keywords are rendered as secondary lines below the title in the Presentation cell. The `metadata.csv` schema, parser, tests, and JSON-LD remain unchanged from #451.

## Type of change

- [ ] feat — a new feature
- [ ] fix — a bug fix
- [ ] docs — documentation or content
- [x] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

Follow-up to #451

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)