### PR TITLE
refactor(files): split title, description and keywords into separate columns

### DIFF
--- a/src/pages/files.astro
+++ b/src/pages/files.astro
@@ -221,8 +221,10 @@ const structuredData = createPageSchema({
           <thead>
             <tr>
               <th scope="col">#</th>
-              <th scope="col">Presentation</th>
+              <th scope="col">Title</th>
+              <th scope="col">Description</th>
               <th scope="col">Topic</th>
+              <th scope="col">Keywords</th>
               <th scope="col">Lang</th>
               <th scope="col">Size</th>
               <th scope="col">Download</th>
@@ -244,10 +246,10 @@ const structuredData = createPageSchema({
                     >
                       {row.title}
                     </a>
-                    {row.description && <span class="presentation-description">{row.description}</span>}
-                    {row.keywords && <span class="presentation-keywords">{row.keywords}</span>}
                   </td>
+                  <td class="presentation-cell">{row.description || '—'}</td>
                   <td>{row.topic}</td>
+                  <td class="presentation-cell presentation-keywords">{row.keywords || '—'}</td>
                   <td>{row.language}</td>
                   <td>{row.size}</td>
                   <td>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -451,8 +451,8 @@ table tr:last-child td {
   max-width: 60ch;
 }
 
-/* Text-heavy cells (title, description, keywords) wrap instead of inheriting
-   the table-wide white-space: nowrap, avoiding a wide horizontal scroll. */
+/* Text-heavy cells (title, description, keywords) wrap instead of inheriting the
+   table-wide white-space: nowrap, avoiding a wide horizontal scroll. */
 .presentations-table .presentation-cell {
   white-space: normal;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -451,9 +451,8 @@ table tr:last-child td {
   max-width: 60ch;
 }
 
-/* The presentation title cell carries long descriptive text (the document title
-   plus description and keyword lines); let it wrap instead of inheriting the
-   table-wide white-space: nowrap, which would force a wide horizontal scroll. */
+/* Text-heavy cells (title, description, keywords) wrap instead of inheriting
+   the table-wide white-space: nowrap, avoiding a wide horizontal scroll. */
 .presentations-table .presentation-cell {
   white-space: normal;
 }
@@ -462,16 +461,7 @@ table tr:last-child td {
   font-weight: 600;
 }
 
-.presentation-description {
-  display: block;
-  margin-top: var(--spacing-1);
-  color: var(--color-text-light);
-  font-size: var(--fontSize-0);
-}
-
 .presentation-keywords {
-  display: block;
-  margin-top: var(--spacing-1);
   color: var(--color-text-light);
   font-size: var(--fontSize-0);
   font-style: italic;


### PR DESCRIPTION
## Description

Split the overloaded "Presentation" column in the `/files/` table into three separate columns:

- **Title** — presentation name, linked to the PDF
- **Description** — short summary from metadata.csv
- **Keywords** — comma-separated tags (italic, lighter color)

The table now has 9 columns: #, Title, Description, Topic, Keywords, Lang, Size, Download, Article. Each piece of information gets its own cell instead of being stacked vertically in one column.

## Type of change

- [ ] feat — a new feature
- [ ] fix — a bug fix
- [ ] docs — documentation or content
- [x] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

Follow-up to #453

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)