### PR TITLE
fix(tables): stretch blog-post (MDX) tables to full column width

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeWrapTables from './src/lib/rehype-wrap-tables.ts';
 import webmanifest from './src/integrations/webmanifest';
 import { buildPostLastmodMap } from './src/lib/sitemap.ts';
 
@@ -84,6 +85,9 @@ export default defineConfig({
     // duplicates the heading in the a11y tree nor becomes a focus trap.
     remarkPlugins: [remarkMath],
     rehypePlugins: [
+      // Wrap content tables in <div class="table-scroll"> so short tables stretch
+      // to full column width (and wide ones scroll) — see rehype-wrap-tables.ts.
+      rehypeWrapTables,
       rehypeKatex,
       rehypeSlug,
       [

--- a/src/lib/rehype-wrap-tables.test.ts
+++ b/src/lib/rehype-wrap-tables.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import rehypeWrapTables from './rehype-wrap-tables';
+
+// Minimal hast-like node shapes; the plugin only inspects type/tagName/name and
+// mutates children arrays, so these stand in for the real compiler output.
+type Node = {
+  type: string;
+  tagName?: string;
+  name?: string;
+  properties?: Record<string, unknown>;
+  children?: Node[];
+};
+
+const run = (tree: Node): Node => {
+  rehypeWrapTables()(tree);
+  return tree;
+};
+
+const root = (...children: Node[]): Node => ({ type: 'root', children });
+const elementTable = (): Node => ({ type: 'element', tagName: 'table', properties: {}, children: [] });
+const mdxTable = (): Node => ({ type: 'mdxJsxFlowElement', name: 'table', attributes: [], children: [] }) as Node;
+
+const isScrollDiv = (node?: Node): boolean =>
+  node?.type === 'element' &&
+  node.tagName === 'div' &&
+  Array.isArray(node.properties?.className) &&
+  (node.properties?.className as string[]).includes('table-scroll');
+
+describe('rehypeWrapTables', () => {
+  it('wraps a Markdown pipe table (hast element) in a .table-scroll div', () => {
+    const tree = root(elementTable());
+    run(tree);
+
+    const wrapper = tree.children![0];
+    expect(isScrollDiv(wrapper)).toBe(true);
+    expect(wrapper.properties?.tabIndex).toBe(0);
+    expect(wrapper.children![0].tagName).toBe('table');
+  });
+
+  it('wraps a raw <table> written in MDX (mdxJsxFlowElement)', () => {
+    const tree = root(mdxTable());
+    run(tree);
+
+    const wrapper = tree.children![0];
+    expect(isScrollDiv(wrapper)).toBe(true);
+    expect(wrapper.children![0].type).toBe('mdxJsxFlowElement');
+    expect(wrapper.children![0].name).toBe('table');
+  });
+
+  it('leaves non-table elements untouched', () => {
+    const p: Node = { type: 'element', tagName: 'p', properties: {}, children: [] };
+    const tree = root(p);
+    run(tree);
+
+    expect(tree.children![0]).toBe(p);
+    expect(isScrollDiv(tree.children![0])).toBe(false);
+  });
+
+  it('is idempotent — does not double-wrap an already wrapped table', () => {
+    const tree = root(elementTable());
+    run(tree); // first pass wraps
+    run(tree); // second pass must not wrap again
+
+    const wrapper = tree.children![0];
+    expect(isScrollDiv(wrapper)).toBe(true);
+    // The wrapper still holds the table directly, not another wrapper.
+    expect(wrapper.children![0].tagName).toBe('table');
+    expect(isScrollDiv(wrapper.children![0])).toBe(false);
+  });
+
+  it('wraps a table nested inside another element (e.g. a cell)', () => {
+    const cell: Node = { type: 'element', tagName: 'td', properties: {}, children: [elementTable()] };
+    const tree = root(cell);
+    run(tree);
+
+    const nested = cell.children![0];
+    expect(isScrollDiv(nested)).toBe(true);
+    expect(nested.children![0].tagName).toBe('table');
+  });
+});

--- a/src/lib/rehype-wrap-tables.ts
+++ b/src/lib/rehype-wrap-tables.ts
@@ -1,0 +1,69 @@
+// Rehype plugin: wrap every content table in <div class="table-scroll">.
+//
+// A bare <table> styled `display: block; overflow-x: auto` (the base rule in
+// main.css) scrolls when wide but, because a block-level table wraps its rows in
+// an anonymous shrink-to-content table box, its cells do NOT stretch to fill the
+// column — short tables leave an empty gap on the right at desktop widths. App
+// pages (setup, bio, metadata, files) avoid this by hand-wrapping their tables in
+// .table-scroll, where the wrapper owns the scroll/border and the inner table is
+// `display: table; width: 100%` so it fills (and still scrolls when wider). MDX
+// post content can't hand-wrap (authors write plain Markdown / raw HTML), so this
+// plugin applies the same wrapper automatically at build time.
+//
+// Two node shapes must be handled: Markdown pipe tables compile to a hast element
+// (tagName "table"), while a raw <table> written in an .mdx file compiles to an
+// mdxJsxFlowElement (name "table"). Already-wrapped tables are left untouched so
+// the transform is idempotent.
+
+interface Node {
+  type: string;
+  tagName?: string;
+  name?: string;
+  properties?: Record<string, unknown>;
+  children?: Node[];
+  [key: string]: unknown;
+}
+
+const TABLE_SCROLL_CLASS = 'table-scroll';
+
+const isTable = (node: Node): boolean =>
+  (node.type === 'element' && node.tagName === 'table') || (node.type === 'mdxJsxFlowElement' && node.name === 'table');
+
+const isTableScrollDiv = (node: Node): boolean => {
+  if (node.type !== 'element' || node.tagName !== 'div') return false;
+  const className = node.properties?.className;
+  return Array.isArray(className) && className.includes(TABLE_SCROLL_CLASS);
+};
+
+// tabIndex makes the scroll container keyboard-focusable so the overflow can be
+// reached without a pointer — matching the hand-wrapped tables on the app pages.
+const wrap = (table: Node): Node => ({
+  type: 'element',
+  tagName: 'div',
+  properties: { className: [TABLE_SCROLL_CLASS], tabIndex: 0 },
+  children: [table],
+});
+
+const transform = (node: Node): void => {
+  const children = node.children;
+  if (!children) return;
+
+  const skipWrap = isTableScrollDiv(node);
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    if (isTable(child) && !skipWrap) {
+      children[i] = wrap(child);
+      transform(child); // descend into the original table for any nested tables
+    } else {
+      transform(child);
+    }
+  }
+};
+
+export default function rehypeWrapTables() {
+  // unified hands the transformer a hast Root, a structural superset of the
+  // minimal Node shape traversed here. Accept it as `unknown` and narrow at this
+  // single seam so the plugin stays assignable to rehype's RehypePlugin type
+  // (a Transformer<Root, Root>) when registered in astro.config.mjs.
+  return (tree: unknown): void => transform(tree as Node);
+}


### PR DESCRIPTION
## Description

On desktop, tables inside blog posts stayed shrunk to their content width and left an empty gap on the right instead of filling the column. On mobile they looked fine because the content already fills the narrow viewport.

**Root cause.** The base rule in `main.css` styles every table `display: block; overflow-x: auto; width: 100%`. That makes a *bare* `<table>` scroll when wide, but a block-level table wraps its rows in an anonymous, shrink-to-content table box — so short tables never stretch. App pages (setup, bio, metadata, files) already dodge this by hand-wrapping their tables in `.table-scroll`, where the wrapper owns the scroll/border and the inner table is `display: table; width: 100%` so it fills (and still scrolls when wider). MDX post content can't hand-wrap, so the gap showed up on posts such as `/domino-tiling/` and `/od-tablicy-do-mapy-harry-potter-i-transmutacja/`.

**Fix.** A small rehype plugin (`src/lib/rehype-wrap-tables.ts`) wraps every content table in `<div class="table-scroll" tabindex="0">` at build time, reusing the existing fill-and-scroll wrapper — no CSS changes. It handles both representations: Markdown pipe tables (hast `element`) and a raw `<table>` written in an `.mdx` file (`mdxJsxFlowElement`). It is idempotent (skips already-wrapped tables) and leaves `.astro` app pages untouched (they aren't processed by the Markdown pipeline).

**Verification.**
- Reproduced the gap in WebKit (Safari engine) and Chromium; confirmed it live on `/domino-tiling/` (308px gap) before the fix.
- A pure-CSS alternative (`display: table` on the bare table) fills short tables but *clips* wide ones (no scroll container) — rejected.
- Full `astro build` of a clean tree: every post table is emitted as `<div class="table-scroll"><table>…`; the two affected posts now fill the column (1px gap); app-page tables unchanged (bio 2/2, setup 3/3, files 1/1, metadata 4/4), no double-wrapping.
- Unit tests cover element/mdxJsxFlowElement/idempotency/non-table cases.

No post content was edited and no URLs change.

## Type of change

- [ ] feat — a new feature
- [x] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)