### PR TITLE
chore: adopt search quality v0.6 action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Verify Google Search quality
         uses: SilesianSolutions/search-quality-kit/action@v0
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           package-manager: pnpm
           config: search-quality.config.ts
           summary: 'true'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,7 +61,13 @@ jobs:
         run: pnpm run check:structured-data
 
       - name: Verify Google Search quality
-        run: pnpm run check:search-quality
+        uses: SilesianSolutions/search-quality-kit/action@v0
+        with:
+          node-version: '24'
+          package-manager: pnpm
+          config: search-quality.config.ts
+          summary: 'true'
+          upload-artifact: 'true'
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Verify Google Search quality
         uses: SilesianSolutions/search-quality-kit/action@v0
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           package-manager: pnpm
           config: search-quality.config.ts
           summary: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,13 @@ jobs:
         run: pnpm run build
 
       - name: Verify Google Search quality
-        run: pnpm run check:search-quality
+        uses: SilesianSolutions/search-quality-kit/action@v0
+        with:
+          node-version: '24'
+          package-manager: pnpm
+          config: search-quality.config.ts
+          summary: 'true'
+          upload-artifact: 'true'
 
       - name: Upload build output
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
-    "@silesiansolutions/search-quality-kit": "0.6.0",
+    "@silesiansolutions/search-quality-kit": "0.6.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.9",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
-    "@silesiansolutions/search-quality-kit": "0.1.3",
+    "@silesiansolutions/search-quality-kit": "0.6.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^1.61.1
         version: 1.61.1
       '@silesiansolutions/search-quality-kit':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.6.1
+        version: 0.6.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -1394,8 +1394,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@silesiansolutions/search-quality-kit@0.6.0':
-    resolution: {integrity: sha512-04WlvPWI1VcY9gUPRouQtfjgZQSUHpoAeTXEz7c6u+G6O9D6P1aQmOGA57tEwp+bzNq+Z8bKdYxolWjO17tAuQ==}
+  '@silesiansolutions/search-quality-kit@0.6.1':
+    resolution: {integrity: sha512-Hz2bw+8Ty4OP+yNlQkb5FqxrZ2fxIcgJM3MXEaXRiomH7iPM9V2ceRxs0O6Kks/SqdNupfM2TQxlexH7sFd0lA==}
     engines: {node: '>=20.11'}
     hasBin: true
 
@@ -5795,7 +5795,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@silesiansolutions/search-quality-kit@0.6.0':
+  '@silesiansolutions/search-quality-kit@0.6.1':
     dependencies:
       cheerio: 1.2.0
       commander: 14.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^1.61.1
         version: 1.61.1
       '@silesiansolutions/search-quality-kit':
-        specifier: 0.1.3
-        version: 0.1.3
+        specifier: 0.6.0
+        version: 0.6.0
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -1394,8 +1394,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@silesiansolutions/search-quality-kit@0.1.3':
-    resolution: {integrity: sha512-akD+uLSplK8n+sxa579buqXEvx/N+gz+uFLMgFWK6yBat7RESTckBAGJr0KRmHlLjpKFwwDhuRkHAXZ2wWnchQ==}
+  '@silesiansolutions/search-quality-kit@0.6.0':
+    resolution: {integrity: sha512-04WlvPWI1VcY9gUPRouQtfjgZQSUHpoAeTXEz7c6u+G6O9D6P1aQmOGA57tEwp+bzNq+Z8bKdYxolWjO17tAuQ==}
     engines: {node: '>=20.11'}
     hasBin: true
 
@@ -5795,7 +5795,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@silesiansolutions/search-quality-kit@0.1.3':
+  '@silesiansolutions/search-quality-kit@0.6.0':
     dependencies:
       cheerio: 1.2.0
       commander: 14.0.3

--- a/search-quality.config.ts
+++ b/search-quality.config.ts
@@ -1,16 +1,17 @@
-import { defineConfig } from '@silesiansolutions/search-quality-kit';
+import { defineConfig, presets, profiles } from '@silesiansolutions/search-quality-kit';
+
+const preset = presets.astro();
 
 export default defineConfig({
+  ...preset,
+  ...profiles.personalSite(),
   site: {
     baseUrl: 'https://dawidrylko.com',
   },
-  build: {
-    distDir: 'dist',
-  },
   crawl: {
+    ...preset.crawl,
     entrypoints: ['/'],
     maxPages: 150,
-    exclude: ['/admin', '/preview', '/api', '/404', '/404.html'],
   },
   ci: {
     failOn: ['error'],


### PR DESCRIPTION
## Description

Upgrades `@silesiansolutions/search-quality-kit` from `0.1.3` to `0.6.1`, applies the Astro preset and personal-site profile, and replaces the raw CLI invocation in CI and CD with the official `search-quality-kit/action@v0` wrapper.

The Action reuses the existing dependency installation and production build, reads the Node.js version from the repository's `.nvmrc`, preserves the CLI exit code, uploads JSON/Markdown reports, and adds the Markdown report to the workflow summary. The existing `ci.failOn: ['error']` policy is unchanged, so warnings remain visible but non-blocking. No content or public URL changes.

Local production validation checked 73 pages with the `personal` profile: 0 errors, 91 warnings, 0 plugin errors. JSON and Markdown reports were generated successfully.

## Type of change

- [ ] feat — a new feature
- [ ] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [x] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)

Additional validation: production build (74 generated pages), 133 unit tests, WCAG AA contrast contract, 75-page structured-data contract, and CI/CD workflow YAML parsing.
