### PR TITLE
fix(seo): align page-level JSON-LD @id/url with canonical

### DIFF
--- a/scripts/ci/check-seo-meta.mjs
+++ b/scripts/ci/check-seo-meta.mjs
@@ -19,6 +19,9 @@
  *   - every inline Person node (the canonical #person) carries a non-empty
  *     sameAs (the social profiles that anchor the author's identity)
  *   - the /bio/ profile page is typed ProfilePage with a Person mainEntity
+ *   - every page-level entity (WebPage/Article/BlogPosting) keeps its url/@id
+ *     aligned with the page canonical, so no ancestor (breadcrumb parent) or
+ *     sibling (listed post) URL leaks in as the page's own identity
  *
  * Redirect stubs (meta-refresh pages such as /resume/) are skipped. Zero
  * dependencies; runs against the built output, it does NOT rebuild. Exits
@@ -79,6 +82,23 @@ function nodeTypes(node) {
   return Array.isArray(node['@type']) ? node['@type'] : [node['@type']];
 }
 
+// schema.org types that represent the page itself; a url/@id on one of these is
+// an identity claim about the current page (matches the search-quality-kit
+// url-consistency rule, which scans exactly these three types).
+const PAGE_LEVEL_TYPES = new Set(['WebPage', 'Article', 'BlogPosting']);
+
+// Canonicalise a URL for identity comparison the same way the audit does: drop
+// the hash fragment (a same-page #fragment @id is allowed), lowercase the host,
+// remove a default port and any trailing slashes (except the root).
+function normalizeUrl(value) {
+  const u = new URL(value);
+  u.hash = '';
+  u.hostname = u.hostname.toLowerCase();
+  if ((u.protocol === 'https:' && u.port === '443') || (u.protocol === 'http:' && u.port === '80')) u.port = '';
+  if (u.pathname !== '/') u.pathname = u.pathname.replace(/\/+$/, '');
+  return u.toString();
+}
+
 function rootTypes(block) {
   return rootNodes(block).flatMap(nodeTypes);
 }
@@ -132,7 +152,31 @@ function checkPage(page, html) {
     // Compare the parsed origin (not a substring) so a look-alike host such as
     // https://dawidrylko.com.evil.com/ cannot pass the check.
     const canonicalOrigin = canonical && URL.canParse(canonical[1]) ? new URL(canonical[1]).origin : null;
-    if (canonicalOrigin !== ORIGIN) fail(`${page}: missing or non-canonical canonical link`);
+    if (canonicalOrigin !== ORIGIN) {
+      fail(`${page}: missing or non-canonical canonical link`);
+    } else {
+      // Every page-level entity must identify THIS page. A WebPage/Article/
+      // BlogPosting node whose url or @id resolves elsewhere makes the page
+      // advertise an ancestor's (breadcrumb parent) or sibling's (listed post)
+      // URL as its own identity, which AI-visibility audits flag.
+      const wantUrl = normalizeUrl(canonical[1]);
+      for (const node of allJsonLdNodes(html)) {
+        const types = nodeTypes(node);
+        if (!types.some(type => PAGE_LEVEL_TYPES.has(type))) continue;
+        for (const prop of ['url', '@id']) {
+          const raw = node[prop];
+          // A same-page '#fragment' @id is allowed; only compare absolute http(s) URLs.
+          if (typeof raw !== 'string' || raw.startsWith('#') || !URL.canParse(raw)) continue;
+          const { protocol } = new URL(raw);
+          if (protocol !== 'http:' && protocol !== 'https:') continue;
+          if (normalizeUrl(raw) !== wantUrl) {
+            fail(
+              `${page}: JSON-LD ${prop} '${raw}' on ${types.join(',')} node differs from canonical '${canonical[1]}'`,
+            );
+          }
+        }
+      }
+    }
   }
 
   for (const [i, block] of ldJsonBlocks(html).entries()) {

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,7 +1,7 @@
 ---
 import { SITE_METADATA } from '../data/site-metadata';
 import JsonLd from './JsonLd.astro';
-import { buildCrumbs } from '../lib/breadcrumbs';
+import { buildCrumbs, breadcrumbListJsonLd } from '../lib/breadcrumbs';
 import type { NavLink } from '../types';
 
 // Builds the trail from the current pathname, mapping known menu segments to
@@ -26,23 +26,7 @@ const crumbs = buildCrumbs({
 });
 const show = crumbs.length > 1;
 
-const structuredData = {
-  '@context': 'https://schema.org',
-  '@type': 'BreadcrumbList',
-  '@id': `${canonical}#breadcrumb`,
-  name: 'Breadcrumb Navigation',
-  description: 'Navigation path showing current location within the website hierarchy',
-  numberOfItems: crumbs.length,
-  itemListElement: crumbs.map((item, index) => ({
-    '@type': 'ListItem',
-    position: index + 1,
-    name: item.name,
-    item:
-      index === crumbs.length - 1
-        ? undefined
-        : { '@type': 'WebPage', '@id': new URL(item.url, siteUrl).href, name: item.title },
-  })),
-};
+const structuredData = breadcrumbListJsonLd(crumbs, canonical, siteUrl);
 ---
 
 {

--- a/src/lib/breadcrumbs.test.ts
+++ b/src/lib/breadcrumbs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCrumbs } from './breadcrumbs';
+import { buildCrumbs, breadcrumbListJsonLd } from './breadcrumbs';
 import type { NavLink } from '../types';
 
 const MENU: NavLink[] = [
@@ -67,5 +67,58 @@ describe('buildCrumbs', () => {
       'Tagi',
       'Tag: devops',
     ]);
+  });
+});
+
+describe('breadcrumbListJsonLd', () => {
+  const SITE = 'https://dawidrylko.com/';
+  const CANONICAL = 'https://dawidrylko.com/tags/devops/';
+
+  const build = () => {
+    const crumbs = buildCrumbs({
+      pathname: '/tags/devops/',
+      customTitle: 'Tag: devops',
+      menu: MENU,
+      parents: [
+        { name: 'Blog 🇵🇱', url: '/blog/' },
+        { name: 'Tagi', url: '/tags/' },
+      ],
+    });
+    return { crumbs, jsonLd: breadcrumbListJsonLd(crumbs, CANONICAL, SITE) };
+  };
+
+  it('emits a BreadcrumbList whose @id is the canonical + #breadcrumb fragment', () => {
+    const { jsonLd } = build();
+    expect(jsonLd['@type']).toBe('BreadcrumbList');
+    expect(jsonLd['@id']).toBe(`${CANONICAL}#breadcrumb`);
+  });
+
+  it('sets numberOfItems to the crumb count with 1-based sequential positions', () => {
+    const { crumbs, jsonLd } = build();
+    expect(jsonLd.numberOfItems).toBe(crumbs.length);
+    expect(jsonLd.itemListElement.map(i => i.position)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('emits every non-active item as an absolute URL string, never a typed node', () => {
+    // Regression: ancestor crumbs used to be { '@type': 'WebPage', '@id' } nodes,
+    // which SEO audits read as the current page advertising its parents' URLs as
+    // its own identity. They must be plain URL strings.
+    const { jsonLd } = build();
+    const nonActive = jsonLd.itemListElement.slice(0, -1);
+    expect(nonActive.map(i => i.item)).toEqual([
+      'https://dawidrylko.com/',
+      'https://dawidrylko.com/blog/',
+      'https://dawidrylko.com/tags/',
+    ]);
+    for (const entry of nonActive) {
+      expect(typeof entry.item).toBe('string');
+    }
+  });
+
+  it('omits the item URL on the active (last) crumb — the current page itself', () => {
+    const { jsonLd } = build();
+    const last = jsonLd.itemListElement.at(-1)!;
+    expect(last.name).toBe('Tag: devops');
+    expect('item' in last).toBe(false);
   });
 });

--- a/src/lib/breadcrumbs.ts
+++ b/src/lib/breadcrumbs.ts
@@ -75,3 +75,30 @@ export function buildCrumbs({ pathname, customTitle, menu, parents = [] }: Build
 
   return crumbs;
 }
+
+// Builds the BreadcrumbList JSON-LD for a page from its crumb trail.
+//
+// Each ListItem's `item` is a PLAIN URL string, not a typed { '@type': 'WebPage',
+// '@id' } node. Google and JSON-LD audit tools read any node typed WebPage /
+// Article / BlogPosting as an identity claim about the *current* page, so
+// emitting ancestor crumbs as WebPage nodes made every subpage advertise its
+// parents' URLs (Home, Blog, …) as its own @id — tripping the url-consistency /
+// id-canonical-mismatch checks. The string form (with `name` on the ListItem) is
+// the canonical breadcrumb shape and carries no such identity claim.
+export function breadcrumbListJsonLd(crumbs: Crumb[], canonical: string, siteUrl: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    '@id': `${canonical}#breadcrumb`,
+    name: 'Breadcrumb Navigation',
+    description: 'Navigation path showing current location within the website hierarchy',
+    numberOfItems: crumbs.length,
+    itemListElement: crumbs.map((crumb, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: crumb.name,
+      // The active (last) crumb is the current page itself and carries no item URL.
+      ...(index === crumbs.length - 1 ? {} : { item: new URL(crumb.url, siteUrl).href }),
+    })),
+  };
+}

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,16 +1,14 @@
 ---
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
-import { Image, getImage } from 'astro:assets';
+import { Image } from 'astro:assets';
 import PageLayout from '../../layouts/PageLayout.astro';
 import JsonLd from '../../components/JsonLd.astro';
 import PostListItem from '../../components/PostListItem.astro';
 import rssIcon from '../../assets/rss.svg';
 import { SITE_METADATA } from '../../data/site-metadata';
 import { STRUCTURED_DATA } from '../../data/structured-data';
-import { excerpt } from '../../lib/excerpt';
 import { getBlogPosts, POSTS_PER_PAGE } from '../../lib/blog';
-import { toISODate } from '../../lib/date';
 import { CONTENT_LANG } from '../../lib/i18n';
 
 const PAGE_METADATA = {
@@ -47,24 +45,6 @@ const isFirstPage = page.currentPage === 1;
 const author = SITE_METADATA.author;
 const { personReference } = STRUCTURED_DATA;
 
-const items = page.data.map(post => {
-  const description = post.data.description || excerpt(post.body ?? '');
-  return { post, description };
-});
-
-// Optimised WebP URL per post for the JSON-LD image, keyed by post id. Using the
-// raw featuredImg.src would emit the full-size original into the build.
-const featuredImageUrls = new Map(
-  await Promise.all(
-    items
-      .filter(({ post }) => post.data.featuredImg)
-      .map(async ({ post }): Promise<[string, string]> => {
-        const image = await getImage({ src: post.data.featuredImg!, width: 1200, format: 'webp' });
-        return [post.id, image.src];
-      }),
-  ),
-);
-
 // Build a stable href for any page number (page 1 keeps the bare /blog/ URL).
 const pageHref = (n: number) => (n === 1 ? '/blog/' : `/blog/${n}/`);
 
@@ -82,28 +62,11 @@ const structuredData = {
   keywords: PAGE_METADATA.keywords.join(', '),
   author: personReference,
   inLanguage: 'pl',
-  blogPost: items.map(({ post, description }) => {
-    const postUrl = `${SITE_METADATA.url}/${post.id}/`;
-    return {
-      '@type': 'BlogPosting',
-      '@id': `${postUrl}#article`,
-      url: postUrl,
-      headline: post.data.title,
-      description,
-      datePublished: toISODate(post.data.date),
-      dateModified: toISODate(post.data.updatedDate ?? post.data.date),
-      author: personReference,
-      publisher: personReference,
-      mainEntityOfPage: { '@id': postUrl },
-      image: post.data.featuredImg
-        ? {
-            '@type': 'ImageObject',
-            url: new URL(featuredImageUrls.get(post.id)!, SITE_METADATA.url).href,
-            description: post.data.featuredImgAlt || '',
-          }
-        : undefined,
-    };
-  }),
+  // Reference each post by @id only: its full BlogPosting node lives on the post
+  // page itself. Inlining full nodes here would advertise other pages' URLs on
+  // the listing, breaking page-level url/@id consistency; the @id edge is enough
+  // for crawlers to resolve the entity across pages.
+  blogPost: page.data.map(post => ({ '@id': `${SITE_METADATA.url}/${post.id}/#article` })),
 };
 ---
 
@@ -143,7 +106,7 @@ const structuredData = {
   <ol id="blog-search-results" class="posts" hidden></ol>
 
   <ol id="blog-posts" class="posts">
-    {items.map(({ post }) => <PostListItem post={post} />)}
+    {page.data.map(post => <PostListItem post={post} />)}
   </ol>
 
   {


### PR DESCRIPTION
## Description

The `@silesiansolutions/search-quality-kit` 0.9.0 audit reported **72 `ai-visibility-safe.url-consistency`** and **7 `structured-data.id-canonical-mismatch`** warnings: page-level JSON-LD entities on subpages carried a `url`/`@id` pointing at an ancestor or sibling URL instead of the page's own canonical.

Two emitters were at fault — both nodes typed `WebPage`/`Article`/`BlogPosting`, which audit tools (and Google) read as an identity claim about the current page:

- **`Breadcrumbs.astro`** emitted every ancestor crumb as a typed `WebPage` node whose `@id` was the ancestor URL (Home, Blog, Tagi…), so all 72 subpages advertised a parent's URL as their own identity.
- **`blog/[...page].astro`** inlined full `BlogPosting` nodes (each with the post's own `url`/`@id`) into the listing's `Blog.blogPost`, so `/blog/`, `/blog/2/`…`/blog/4/` advertised the first listed post's URL.

Fix:

- Breadcrumb items are now plain URL strings (the canonical `BreadcrumbList` shape, `name` on the `ListItem`) via a new `breadcrumbListJsonLd` builder in `src/lib/breadcrumbs.ts` — no ancestor is emitted as a typed node.
- The blog listing references each post by `@id` only; the full `BlogPosting` node already lives on each post's own page, so crawlers still resolve the entity across pages.
- `scripts/ci/check-seo-meta.mjs` gains a page-level identity assertion (every `WebPage`/`Article`/`BlogPosting` node's `url`/`@id` must normalize to the page canonical) so this regresses loudly in CI, and `breadcrumbListJsonLd` is unit-tested.

### Verification

- `pnpm build` + `pnpm exec search-quality-kit verify --skip-build --report-only`:
  - `ai-visibility-safe.url-consistency`: **72 → 0**
  - `structured-data.id-canonical-mismatch`: **7 → 0**
  - `structured-data.article-recommended-properties`: 26 → 23 (fewer incomplete inline nodes), no new findings; total 171 → 89.
- New `check-seo-meta.mjs` assertion fails on the pre-fix build (239 leaked identity claims) and passes after the fix.
- `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check`, `pnpm test` (137 tests) all green.

## Type of change

- [x] fix — a bug fix

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)
