### PR TITLE
chore: update search quality kit to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
-    "@silesiansolutions/search-quality-kit": "0.9.0",
+    "@silesiansolutions/search-quality-kit": "0.10.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^1.61.1
         version: 1.61.1
       '@silesiansolutions/search-quality-kit':
-        specifier: 0.9.0
-        version: 0.9.0
+        specifier: 0.10.0
+        version: 0.10.0
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -1338,8 +1338,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@silesiansolutions/search-quality-kit@0.9.0':
-    resolution: {integrity: sha512-zJD5ALxQ1JntpP042mCt1GX9OTP48x8mWO/XUzFcFxZuHOzeUnrfAm8wrjTA1P4SJv6y4mrQohp/ElhC/dQ8IA==}
+  '@silesiansolutions/search-quality-kit@0.10.0':
+    resolution: {integrity: sha512-IpqPGMIPYLGvTCA3V1DJQnv0KYcgS44oZzgv6O6cyha6ACERDzBGIi4p5+kU0DBle6F1imlUX0eS5Ho8cpyzow==}
     engines: {node: '>=20.11'}
     hasBin: true
 
@@ -5704,7 +5704,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@silesiansolutions/search-quality-kit@0.9.0':
+  '@silesiansolutions/search-quality-kit@0.10.0':
     dependencies:
       cheerio: 1.2.0
       commander: 14.0.3


### PR DESCRIPTION
## Description

Update `@silesiansolutions/search-quality-kit` from 0.9.0 to 0.10.0. The 0.10.0 release adds a
default-on `agentReadiness` check that audits `/llms.txt` (H1, blockquote summary, Markdown links,
50-char minimum) and scans delivered HTML `<form>`s for declarative WebMCP annotations. It runs
inside the existing CI/CD search-quality gate; no config change is needed — the config API
(`presets.astro()`, `profiles.personalSite()`, policy packs) is unchanged in 0.10.0, and the
transitive dependency graph is identical between 0.9.0 and 0.10.0 (so the lockfile change is only
the package's own version and integrity).

The site already satisfies the check: `static/llms.txt` passes every content rule and there are no
user-facing forms, so `agentReadiness` reports 0 findings. All agent-readiness findings are
`info`/`warning`, so the `failOn: ['error']` gate is unchanged — the check is advisory (surfaced in
the job summary), not blocking.

Verification: built `dist/` and ran the repo's config under a 0.10.0 build — `agentReadiness` 0
findings, gate exit 0; a deliberately broken `llms.txt` produced the expected findings (advisory).

## Type of change

- [x] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [ ] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally — deferred to CI (dependency-only change; not run in the authoring environment)
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)
