### PR TITLE
chore(deps): update search-quality-kit to 0.11.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         run: pnpm run doctor:search-quality
 
       - name: Verify Google Search quality
-        uses: SilesianSolutions/search-quality-kit/action@v0
+        uses: SilesianSolutions/search-quality-kit@v0
         with:
           node-version-file: '.nvmrc'
           package-manager: pnpm

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.62.1",
-    "@silesiansolutions/search-quality-kit": "0.10.0",
+    "@silesiansolutions/search-quality-kit": "0.11.2",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^1.62.1
         version: 1.62.1
       '@silesiansolutions/search-quality-kit':
-        specifier: 0.10.0
-        version: 0.10.0
+        specifier: 0.11.2
+        version: 0.11.2
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -1200,8 +1200,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@silesiansolutions/search-quality-kit@0.10.0':
-    resolution: {integrity: sha512-IpqPGMIPYLGvTCA3V1DJQnv0KYcgS44oZzgv6O6cyha6ACERDzBGIi4p5+kU0DBle6F1imlUX0eS5Ho8cpyzow==}
+  '@silesiansolutions/search-quality-kit@0.11.2':
+    resolution: {integrity: sha512-m/XNXERlHbLEk9pWA3GwecdsKUYxGs9DAFcFryLgdvYlg1Vi7qs8vHbNLf+aP1uKzH2ttKwe5mQwAsHUGGIEFA==}
     engines: {node: '>=20.11'}
     hasBin: true
 
@@ -5422,7 +5422,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@silesiansolutions/search-quality-kit@0.10.0':
+  '@silesiansolutions/search-quality-kit@0.11.2':
     dependencies:
       cheerio: 1.2.0
       commander: 14.0.3


### PR DESCRIPTION
## Description

Updates `@silesiansolutions/search-quality-kit` from `0.10.0` to `0.11.2`, and shortens the Action reference to the root path published in 0.11.0.

**Why it matters here.** 0.11.0 adds a default-on `hreflang` check, and this site is one of the few that actually exercises it — `PageLayout.astro` emits a self-referencing alternate plus an `x-default` on every indexable page, so the check evaluates it rather than short-circuiting on a site with no annotations.

Nothing in the site needs to change for it. Each rule was checked against the source:

| Rule | Why it passes |
|---|---|
| `invalid-language` | `metaLang` is `en` (`site-metadata.ts`) or `pl` (`i18n.ts` `CONTENT_LANG`) — both ISO 639-1 |
| `relative-href` | `new URL(pathname, Astro.site).href` — absolute |
| `non-canonical-target` | the alternate href *is* the canonical |
| `lang-mismatch` | `<html lang>` comes from the same `metaLang` |
| `missing-self` | every page names its own language |
| `missing-reciprocal` | each page names only itself, so clusters are singletons |
| `x-default-duplicate` | exactly one per page |

The layout comment already asserts the site is "monolingual per URL … the hreflang annotations all agree on it". The check now enforces that claim instead of trusting it.

**The lockfile needed care.** CI runs `pnpm install --frozen-lockfile`, so bumping `package.json` alone would fail the build. Regenerating with a pnpm other than the pinned `10.33.0` produced 54 lines of collateral damage — it stripped `libc:` fields from the Astro compiler bindings and silently downgraded a transitive `vite` from 8.2.1 to 8.2.0. That was discarded and the exact pinned pnpm used instead; the lockfile diff is now 5 changed lines with transitive resolution untouched.

Two bug-fix releases sit between 0.10.0 and 0.11.2, neither affecting this repo: `0.11.1` fixed the Action failing where the kit is not a dependency (it is one here, driven through `package-manager: pnpm`), and `0.11.2` fixed false `missing-static-route` errors on flat `<route>.html` output (this build uses Astro's default directory output).

## Type of change

- [x] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [ ] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally — **not run locally**; pnpm could not execute in this environment. All of them ran in CI on this PR and are green, which is the stronger evidence.
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO) — dependency-only change, no routing or content touched