### PR TITLE
feat(seo): add image sitemap, reorder /metadata/ AI Resources

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeWrapTables from './src/lib/rehype-wrap-tables.ts';
 import webmanifest from './src/integrations/webmanifest';
+import sitemapImages from './src/integrations/sitemap-images';
 import { buildPostLastmodMap } from './src/lib/sitemap.ts';
 
 // Post lastmod dates (updatedDate ?? date), read from frontmatter so the sitemap
@@ -71,6 +72,10 @@ export default defineConfig({
       },
     }),
     webmanifest(),
+    // Must follow sitemap(): both write into dist/ on astro:build:done, and the
+    // image sitemap is a separate file that @astrojs/sitemap cannot include in
+    // its index — robots.txt and /sitemap.xml advertise it instead.
+    sitemapImages(),
   ],
   // Responsive images (stable in Astro 6): every <Image>/<Picture> and Markdown
   // image gets a srcset + sizes + responsive styles automatically. Replaces

--- a/scripts/ci/check-crawl-hygiene.mjs
+++ b/scripts/ci/check-crawl-hygiene.mjs
@@ -12,10 +12,12 @@
  *     stay client-side only, out of crawler/Ahrefs text extraction)
  *   - robots.txt directives each sit on their own line (none glued together,
  *     which would make a directive unparseable) and a Sitemap is declared
+ *   - every image advertised in the image sitemap was actually emitted, so the
+ *     sitemap can never promise Google an asset the build did not produce
  *
- * The pure helpers (`findArtifactViolations`, `findGluedRobotsDirectives`) are
- * unit-tested in check-crawl-hygiene.test.mjs. Exits non-zero listing every
- * problem found.
+ * The pure helpers (`findArtifactViolations`, `findGluedRobotsDirectives`,
+ * `extractImageLocs`) are unit-tested in check-crawl-hygiene.test.mjs. Exits
+ * non-zero listing every problem found.
  */
 
 import { readFile, readdir, access } from 'node:fs/promises';
@@ -48,6 +50,28 @@ export function findGluedRobotsDirectives(robotsTxt) {
   return offending;
 }
 
+// Pure: return every <image:loc> URL declared in an image sitemap, in order.
+// `&amp;` is undone LAST: unescaping the meta-character first would re-expose an
+// ampersand that the following passes then consume a second time, so an escaped
+// literal "&lt;" (written "&amp;lt;") would decode to "<" instead of "&lt;".
+export function extractImageLocs(xml) {
+  return [...xml.matchAll(/<image:loc>\s*([^<]+?)\s*<\/image:loc>/g)].map(([, loc]) =>
+    loc
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, '&'),
+  );
+}
+
+// Pure: the dist-relative path a sitemap image URL should resolve to. Sitemap
+// URLs are percent-encoded per RFC 3986, but several post images carry Polish
+// diacritics and en-dashes in their filename and land on disk as raw UTF-8 —
+// so the encoding has to be undone before touching the filesystem.
+export function distPathForLoc(loc) {
+  return decodeURIComponent(new URL(loc, 'https://dawidrylko.com').pathname);
+}
+
 // The URLs an SEO/AI crawl must always find. HTML pages plus the machine
 // artifacts that anchor discovery (robots, feeds, sitemaps, llms.txt).
 const REQUIRED_HTML = [
@@ -61,7 +85,15 @@ const REQUIRED_HTML = [
   'tags/index.html',
   '404.html',
 ];
-const REQUIRED_ASSETS = ['robots.txt', 'rss.xml', 'sitemap-index.xml', 'sitemap-0.xml', 'sitemap.xml', 'llms.txt'];
+const REQUIRED_ASSETS = [
+  'robots.txt',
+  'rss.xml',
+  'sitemap-index.xml',
+  'sitemap-0.xml',
+  'sitemap.xml',
+  'sitemap-images.xml',
+  'llms.txt',
+];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -121,6 +153,20 @@ async function main() {
     if (!/^\s*Sitemap\s*:/im.test(robots)) fail('robots.txt does not declare a Sitemap');
   }
 
+  // The image sitemap must only advertise images the build actually emitted;
+  // a 404 in an image sitemap is a hard error for Google Images.
+  const imageSitemapPath = join(distDir, 'sitemap-images.xml');
+  let imageLocs = [];
+  if (await exists(imageSitemapPath)) {
+    imageLocs = extractImageLocs(await readFile(imageSitemapPath, 'utf8'));
+    if (imageLocs.length === 0) fail('sitemap-images.xml advertises no images');
+    for (const loc of imageLocs) {
+      if (!(await exists(join(distDir, distPathForLoc(loc))))) {
+        fail(`image sitemap points at a file missing from the build: ${loc}`);
+      }
+    }
+  }
+
   console.log('Crawl-hygiene contract (dist/)\n');
   if (problems.length > 0) {
     for (const problem of problems) console.error(`  ✗ ${problem}`);
@@ -129,7 +175,8 @@ async function main() {
   }
   console.log(
     `  ✓ ${REQUIRED_HTML.length + REQUIRED_ASSETS.length} required URL(s) present; ` +
-      `${pages.length} page(s) free of the ASCII artifact; robots.txt directives well-formed.`,
+      `${pages.length} page(s) free of the ASCII artifact; robots.txt directives well-formed; ` +
+      `${imageLocs.length} image sitemap entr(ies) resolve to emitted files.`,
   );
 }
 

--- a/scripts/ci/check-crawl-hygiene.test.mjs
+++ b/scripts/ci/check-crawl-hygiene.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { findArtifactViolations, findGluedRobotsDirectives, SIGNATURE_ARTIFACT } from './check-crawl-hygiene.mjs';
+import {
+  distPathForLoc,
+  extractImageLocs,
+  findArtifactViolations,
+  findGluedRobotsDirectives,
+  SIGNATURE_ARTIFACT,
+} from './check-crawl-hygiene.mjs';
 
 describe('findArtifactViolations', () => {
   it('returns no violations when no page leaks the signature', () => {
@@ -40,5 +46,56 @@ describe('findGluedRobotsDirectives', () => {
   it('ignores directive keywords appearing inside comments', () => {
     const robots = '# Sitemap: note and Allow: hint live in a comment\nUser-agent: *\nAllow: /';
     expect(findGluedRobotsDirectives(robots)).toEqual([]);
+  });
+});
+
+describe('extractImageLocs', () => {
+  it('returns every image loc, not the page loc', () => {
+    const xml = [
+      '<urlset>',
+      '  <url>',
+      '    <loc>https://dawidrylko.com/post/</loc>',
+      '    <image:image><image:loc>https://dawidrylko.com/_astro/a.png</image:loc></image:image>',
+      '    <image:image><image:loc>https://dawidrylko.com/_astro/b.jpg</image:loc></image:image>',
+      '  </url>',
+      '</urlset>',
+    ].join('\n');
+    expect(extractImageLocs(xml)).toEqual([
+      'https://dawidrylko.com/_astro/a.png',
+      'https://dawidrylko.com/_astro/b.jpg',
+    ]);
+  });
+
+  it('decodes XML entities back into the real URL', () => {
+    const xml = '<image:image><image:loc>https://dawidrylko.com/_astro/a.png?w=1&amp;h=2</image:loc></image:image>';
+    expect(extractImageLocs(xml)).toEqual(['https://dawidrylko.com/_astro/a.png?w=1&h=2']);
+  });
+
+  it('does not double-unescape an escaped entity', () => {
+    // "&amp;lt;" is the escaped form of the literal text "&lt;" — decoding it
+    // must stop there and not go on to produce "<".
+    const xml = '<image:loc>https://dawidrylko.com/_astro/a.png?q=&amp;lt;</image:loc>';
+    expect(extractImageLocs(xml)).toEqual(['https://dawidrylko.com/_astro/a.png?q=&lt;']);
+  });
+
+  it('returns nothing for a sitemap without images', () => {
+    expect(extractImageLocs('<urlset><url><loc>https://dawidrylko.com/</loc></url></urlset>')).toEqual([]);
+  });
+});
+
+describe('distPathForLoc', () => {
+  it('decodes percent-encoded filenames back to the raw UTF-8 name on disk', () => {
+    expect(distPathForLoc('https://dawidrylko.com/_astro/2.Nowy_projekt%E2%80%93Google.CfOhSI-L_Zi8DzN.webp')).toBe(
+      '/_astro/2.Nowy_projekt–Google.CfOhSI-L_Zi8DzN.webp',
+    );
+    expect(distPathForLoc('https://dawidrylko.com/_astro/1.Konta_us%C5%82ugi.Cj1y5E2U_2ayvHc.webp')).toBe(
+      '/_astro/1.Konta_usługi.Cj1y5E2U_2ayvHc.webp',
+    );
+  });
+
+  it('leaves a plain ASCII path untouched', () => {
+    expect(distPathForLoc('https://dawidrylko.com/_astro/domino.BBW36BnX_Z2wNLpc.webp')).toBe(
+      '/_astro/domino.BBW36BnX_Z2wNLpc.webp',
+    );
   });
 });

--- a/src/integrations/sitemap-images.ts
+++ b/src/integrations/sitemap-images.ts
@@ -1,0 +1,66 @@
+import type { AstroIntegration } from 'astro';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { SITE_METADATA } from '../data/site-metadata';
+import { buildImageSitemap, extractPostImageUrls } from '../lib/sitemap';
+
+// Google image sitemap. @astrojs/sitemap emits page URLs only, so the 100+
+// diagrams and screenshots co-located with the posts are invisible to Google
+// Images: they ship as content-hashed /_astro/ assets that nothing but a
+// srcset-parsing crawl would ever find.
+//
+// It runs on astro:build:done, over the emitted HTML, rather than as a route:
+// a route would have to re-derive each URL through getImage(), which produces a
+// *valid but different* variant of every image — a second copy of the whole
+// responsive set (measured: +262 files, +69 MB on a 195 MB dist) that appears on
+// no page. Reading the built markup instead costs nothing and is correct by
+// construction: what is listed is literally what the page displays.
+const SITEMAP_FILE = 'sitemap-images.xml';
+
+async function collectHtml(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return collectHtml(full);
+      return entry.name.endsWith('.html') ? [full] : [];
+    }),
+  );
+  return files.flat();
+}
+
+export default function sitemapImages(): AstroIntegration {
+  let origin = SITE_METADATA.url;
+
+  return {
+    name: 'sitemap-images',
+    hooks: {
+      'astro:config:done': ({ config }) => {
+        if (config.site) origin = new URL(config.site).origin;
+      },
+      'astro:build:done': async ({ dir, logger }) => {
+        const outDir = fileURLToPath(dir);
+        const entries = [];
+
+        for (const file of await collectHtml(outDir)) {
+          const images = extractPostImageUrls(await readFile(file, 'utf8'));
+          if (images.length === 0) continue;
+
+          // dist/a/b/index.html -> /a/b/ , matching trailingSlash: 'always'.
+          const relative = path.relative(outDir, path.dirname(file)).split(path.sep).join('/');
+          entries.push({ pathname: `/${relative}/`, images });
+        }
+
+        // Sorted so the output is byte-stable across builds.
+        entries.sort((a, b) => a.pathname.localeCompare(b.pathname));
+        await writeFile(path.join(outDir, SITEMAP_FILE), buildImageSitemap(entries, origin), 'utf8');
+
+        const total = entries.reduce((sum, entry) => sum + entry.images.length, 0);
+        logger.info(
+          `\`${SITEMAP_FILE}\` created at \`${path.basename(outDir)}\` — ${total} image(s), ${entries.length} page(s)`,
+        );
+      },
+    },
+  };
+}

--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { postSlug, lastmodFromFrontmatter } from './sitemap';
+import { readFileSync } from 'node:fs';
+import { postSlug, lastmodFromFrontmatter, extractPostImageUrls, buildImageSitemap, POST_ARTICLE_TAG } from './sitemap';
 
 describe('postSlug', () => {
   it('strips the YYYY-MM-DD-- date prefix', () => {
@@ -25,5 +26,85 @@ describe('lastmodFromFrontmatter', () => {
 
   it('returns null when no date is present', () => {
     expect(lastmodFromFrontmatter('title: Something')).toBeNull();
+  });
+});
+
+const postPage = (article: string, chrome = '') =>
+  `<body>${chrome}<article class="blog-post">${article}</article><footer>${chrome}</footer></body>`;
+
+describe('POST_ARTICLE_TAG', () => {
+  // Guards the one coupling the image sitemap cannot detect at runtime: if the
+  // post template stops emitting this exact tag, every post silently reports
+  // zero images and the sitemap shrinks without any build or CI step failing.
+  it('is still the wrapper the post template emits', () => {
+    const template = readFileSync(new URL('../pages/[...slug].astro', import.meta.url), 'utf8');
+    expect(template).toContain(POST_ARTICLE_TAG);
+  });
+});
+
+describe('extractPostImageUrls', () => {
+  it('returns the post images in document order', () => {
+    const html = postPage(
+      '<img src="/_astro/featured.aaa_1.webp" alt="F"><section><img src="/_astro/diagram.bbb_2.webp" alt="D"></section>',
+    );
+    expect(extractPostImageUrls(html)).toEqual(['/_astro/featured.aaa_1.webp', '/_astro/diagram.bbb_2.webp']);
+  });
+
+  it('ignores chrome images outside the post article, such as the Bio avatar', () => {
+    const html = postPage(
+      '<img src="/_astro/diagram.bbb_2.webp" alt="D">',
+      '<img src="/_astro/avatar.ccc_3.webp" alt="A">',
+    );
+    expect(extractPostImageUrls(html)).toEqual(['/_astro/diagram.bbb_2.webp']);
+  });
+
+  it('collapses repeats, which is what content-deduplicated source files produce', () => {
+    const html = postPage('<img src="/_astro/same.ddd_4.webp"><img src="/_astro/same.ddd_4.webp">');
+    expect(extractPostImageUrls(html)).toEqual(['/_astro/same.ddd_4.webp']);
+  });
+
+  it('reads src regardless of the attributes preceding it', () => {
+    const html = postPage('<img alt="A" loading="lazy" decoding="async" src="/_astro/late.eee_5.webp" width="10">');
+    expect(extractPostImageUrls(html)).toEqual(['/_astro/late.eee_5.webp']);
+  });
+
+  it('returns nothing for a page that is not a post', () => {
+    expect(extractPostImageUrls('<body><main><img src="/_astro/hero.fff_6.webp"></main></body>')).toEqual([]);
+  });
+});
+
+describe('buildImageSitemap', () => {
+  it('nests every image under the page it appears on', () => {
+    const xml = buildImageSitemap(
+      [{ pathname: '/post/', images: ['/_astro/a.webp', '/_astro/b.webp'] }],
+      'https://dawidrylko.com',
+    );
+    expect(xml).toContain('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"');
+    expect(xml).toContain('<loc>https://dawidrylko.com/post/</loc>');
+    expect(xml).toContain('<image:image><image:loc>https://dawidrylko.com/_astro/a.webp</image:loc></image:image>');
+    expect(xml).toContain('<image:image><image:loc>https://dawidrylko.com/_astro/b.webp</image:loc></image:image>');
+  });
+
+  it('omits pages that carry no images', () => {
+    const xml = buildImageSitemap(
+      [
+        { pathname: '/text-only/', images: [] },
+        { pathname: '/illustrated/', images: ['/_astro/a.webp'] },
+      ],
+      'https://dawidrylko.com',
+    );
+    expect(xml).not.toContain('/text-only/');
+    expect(xml).toContain('/illustrated/');
+  });
+
+  it('escapes XML metacharacters in URLs', () => {
+    const xml = buildImageSitemap([{ pathname: '/p/', images: ['/_astro/a.webp?w=1&h=2'] }], 'https://dawidrylko.com');
+    expect(xml).toContain('<image:loc>https://dawidrylko.com/_astro/a.webp?w=1&amp;h=2</image:loc>');
+  });
+
+  it('stays well-formed when nothing has images', () => {
+    const xml = buildImageSitemap([], 'https://dawidrylko.com');
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml.trimEnd().endsWith('</urlset>')).toBe(true);
   });
 });

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -15,6 +15,56 @@ export function lastmodFromFrontmatter(frontmatter: string): string | null {
   return updated ?? date ?? null;
 }
 
+// The post body wrapper emitted by [...slug].astro. Scoping to it is what
+// separates a post's own images (featured image + everything the Markdown
+// renders) from site chrome that also carries an <img> — the Bio avatar sits
+// outside this element.
+//
+// Exported because it is the single point of coupling between that template and
+// this module: renaming the class there would empty the image sitemap one post
+// at a time, silently, since a post with no images is also a legitimate result.
+// sitemap.test.ts asserts the template still emits exactly this string.
+export const POST_ARTICLE_TAG = '<article class="blog-post">';
+const POST_ARTICLE = new RegExp(`${POST_ARTICLE_TAG}([\\s\\S]*?)</article>`);
+const IMG_SRC = /<img\b[^>]*?\ssrc="([^"]+)"/g;
+
+// Extract the images a built post page actually displays, de-duplicated, in
+// document order. Reading the emitted HTML — rather than re-deriving URLs from
+// the Markdown source — is what makes the image sitemap agree with the page by
+// construction: identical source files are content-deduplicated into a single
+// /_astro/ asset by the build, and reproducing the exact transform hash from
+// outside the render pipeline is not something getImage() can be asked for.
+export function extractPostImageUrls(html: string): string[] {
+  const article = html.match(POST_ARTICLE)?.[1];
+  if (!article) return [];
+
+  return [...new Set([...article.matchAll(IMG_SRC)].map(([, src]) => src))];
+}
+
+const escapeXml = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+// Render the Google image sitemap extension. Deliberately image:loc only:
+// image:caption, image:title, image:license and image:geo_location were
+// deprecated by Google in 2022 and are ignored.
+export function buildImageSitemap(entries: { pathname: string; images: string[] }[], origin: string): string {
+  const urls = entries
+    .filter(entry => entry.images.length > 0)
+    .map(entry => {
+      const images = entry.images
+        .map(src => `    <image:image><image:loc>${escapeXml(origin + src)}</image:loc></image:image>`)
+        .join('\n');
+      return `  <url>\n    <loc>${escapeXml(origin + entry.pathname)}</loc>\n${images}\n  </url>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+${urls}
+</urlset>
+`;
+}
+
 // Map each top-level post slug to its lastmod by reading frontmatter directly
 // from disk. Used by the sitemap serializer in astro.config.mjs, which runs
 // outside the Astro content pipeline and so cannot use getCollection().

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -23,13 +23,19 @@ const siteDescription = SITE_METADATA.description.en;
 
 // Resources curated for AI/LLM crawlers and agents. Exposed here in addition to
 // /llms.txt and robots.txt so the intent is discoverable from the site itself.
+// Ordered as a crawler would walk them: crawl policy, then the sitemaps it points
+// to, then the feeds, then the LLM summary, with this page last. Human-facing
+// pages (/bio/, /blog/) are deliberately absent — they are already in the
+// sitemaps and in the Pages table below, and are not machine-readable artifacts.
 const aiResources: [string, string][] = [
+  ['/robots.txt', 'Crawl policy — all crawlers, AI included, are explicitly allowed; declares the sitemaps.'],
+  ['/sitemap-index.xml', 'Canonical sitemap index; the one advertised in robots.txt.'],
+  ['/sitemap.xml', 'Conventional sitemap index, for crawlers that probe this path.'],
+  ['/sitemap-0.xml', 'The URL set itself: every page, with lastmod and priority.'],
+  ['/sitemap-images.xml', 'Google image sitemap: every post image, mapped to the page it appears on.'],
+  ['/rss.xml', 'Full-text RSS feed of every blog post.'],
   ['/llms.txt', 'Structured, machine-readable summary of the site for AI/LLM crawlers.'],
   ['/metadata/', 'This page — full inventory of pages and blog posts with build info.'],
-  ['/bio/', 'Author background: experience, education, and philosophy.'],
-  ['/blog/', 'All articles, with search and tag filtering.'],
-  ['/rss.xml', 'Full-text RSS feed of every blog post.'],
-  ['/sitemap-index.xml', 'Canonical list of all URLs.'],
 ];
 
 const siteInfo: [string, string][] = [

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -6,11 +6,15 @@ import type { APIRoute } from 'astro';
 // conventional /sitemap.xml path instead; this thin sitemap index answers them
 // with valid XML — not an HTML meta-refresh redirect, which a strict XML parser
 // would reject — pointing at the same generated url set.
+//
+// It also carries /sitemap-images.xml, which @astrojs/sitemap cannot emit and so
+// is absent from its index; robots.txt advertises that one directly as well.
 export const GET: APIRoute = ({ site }) => {
   const origin = (site ?? new URL('https://dawidrylko.com')).origin;
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap><loc>${origin}/sitemap-0.xml</loc></sitemap>
+  <sitemap><loc>${origin}/sitemap-images.xml</loc></sitemap>
 </sitemapindex>
 `;
   return new Response(body, {

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -35,6 +35,8 @@ automation, cybersecurity, DevOps, IoT, smart home.
 
 - [RSS feed](https://dawidrylko.com/rss.xml): full-text feed of all blog posts.
 - [Sitemap](https://dawidrylko.com/sitemap-index.xml): canonical list of all URLs.
+- [Image sitemap](https://dawidrylko.com/sitemap-images.xml): every post image, mapped to the page it appears on.
+- [Metadata](https://dawidrylko.com/metadata/): full inventory of pages and posts, with build info.
 
 ## Contact
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -37,3 +37,7 @@ Allow: /
 # llms.txt: https://dawidrylko.com/llms.txt
 
 Sitemap: https://dawidrylko.com/sitemap-index.xml
+
+# Post images (Google Image sitemap extension). Declared separately because
+# @astrojs/sitemap builds sitemap-index.xml and cannot include it.
+Sitemap: https://dawidrylko.com/sitemap-images.xml


### PR DESCRIPTION
## Description

Post images ship as content-hashed `/_astro/` assets and `@astrojs/sitemap` emits page URLs only, so Google Images never finds them. A new `astro:build:done` integration writes `/sitemap-images.xml` (112 images, 34 pages) from the emitted post HTML — not from a route, because a route has to re-derive every URL through `getImage()`, which returns a valid but *different* variant of each image: a second copy of the whole responsive set (+262 files, +69 MB on a 195 MB `dist`) that appears on no page.

| plik / obszar | co się zmienia |
| --- | --- |
| `src/integrations/sitemap-images.ts` | nowa integracja `astro:build:done` generująca sitemapę obrazków |
| `src/lib/sitemap.ts` | `extractPostImageUrls` + `buildImageSitemap`; `POST_ARTICLE_TAG` = jedyne sprzężenie z szablonem posta, pilnowane testem |
| `src/pages/metadata.astro` | AI Resources: kolejność wg ścieżki crawlera, bez `/bio/` i `/blog/` (są już w sitemapach i w tabeli Pages) |
| `src/pages/sitemap.xml.ts`, `static/robots.txt`, `static/llms.txt` | ogłoszenie nowej sitemapy |
| `scripts/ci/check-crawl-hygiene.mjs` | bramka: każdy `<image:loc>` musi istnieć w `dist/` |

Weryfikacja na czystym drzewie: 112/112 `<image:loc>` to własny `<img src>` strony, `dist` bez zmian (195 MB, 1428 assetów), 152 testy jednostkowe. Bramka złapała 9 nazw z polskimi znakami kodowanych procentowo.

## Type of change

- [x] feat — a new feature

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)
