### PR TITLE
fix(seo): register the image sitemap in the canonical sitemap index

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,13 +16,17 @@ import { buildPostLastmodMap } from './src/lib/sitemap.ts';
 // can advertise per-post freshness. Built once at config load.
 const postLastmod = await buildPostLastmodMap();
 
+// Single source for the deployed origin: `site` and the sitemap index entries
+// must not drift apart.
+const SITE = 'https://dawidrylko.com';
+
 // Content pipeline (migrated from Gatsby):
 //   - MDX with remark-math + rehype-katex (KaTeX, build-time SSR)
 //   - Shiki syntax highlighting with light/dark themes (replaces Prism)
 //   - React islands for interactive components (Mermaid, embedded demos)
 // https://docs.astro.build/en/reference/configuration-reference/
 export default defineConfig({
-  site: 'https://dawidrylko.com',
+  site: SITE,
   // Trailing-slash URLs preserved from the Gatsby site so links/redirects match.
   trailingSlash: 'always',
   // Static assets (resume PDFs, /files, robots.txt, CNAME) served from static/.
@@ -47,6 +51,11 @@ export default defineConfig({
     mdx(),
     react(),
     sitemap({
+      // The image sitemap is written by the sitemapImages() integration below,
+      // outside this plugin's own url set — customSitemaps is what still gets it
+      // listed in the canonical sitemap-index.xml, so the index that robots.txt
+      // advertises is complete and nothing depends on a second discovery path.
+      customSitemaps: [`${SITE}/sitemap-images.xml`],
       // Enrich each entry: per-post lastmod from frontmatter, plus a priority
       // hint by route type (homepage > blog listings > posts > tags).
       serialize(item) {
@@ -72,9 +81,9 @@ export default defineConfig({
       },
     }),
     webmanifest(),
-    // Must follow sitemap(): both write into dist/ on astro:build:done, and the
-    // image sitemap is a separate file that @astrojs/sitemap cannot include in
-    // its index — robots.txt and /sitemap.xml advertise it instead.
+    // Writes sitemap-images.xml, which sitemap() above registers in the index
+    // via customSitemaps. Both run on astro:build:done and touch different files,
+    // so their relative order does not matter.
     sitemapImages(),
   ],
   // Responsive images (stable in Astro 6): every <Image>/<Picture> and Markdown

--- a/scripts/ci/check-crawl-hygiene.mjs
+++ b/scripts/ci/check-crawl-hygiene.mjs
@@ -14,10 +14,13 @@
  *     which would make a directive unparseable) and a Sitemap is declared
  *   - every image advertised in the image sitemap was actually emitted, so the
  *     sitemap can never promise Google an asset the build did not produce
+ *   - the canonical sitemap index reaches every sitemap we publish, so no
+ *     sitemap depends on robots.txt alone to be discovered
  *
  * The pure helpers (`findArtifactViolations`, `findGluedRobotsDirectives`,
- * `extractImageLocs`) are unit-tested in check-crawl-hygiene.test.mjs. Exits
- * non-zero listing every problem found.
+ * `extractImageLocs`, `extractSitemapIndexLocs`, `distPathForLoc`) are
+ * unit-tested in check-crawl-hygiene.test.mjs. Exits non-zero listing every
+ * problem found.
  */
 
 import { readFile, readdir, access } from 'node:fs/promises';
@@ -62,6 +65,19 @@ export function extractImageLocs(xml) {
       .replace(/&quot;/g, '"')
       .replace(/&amp;/g, '&'),
   );
+}
+
+// Pure: return every <loc> a sitemap index points at, in order.
+export function extractSitemapIndexLocs(xml) {
+  return [...xml.matchAll(/<sitemap>[\s\S]*?<loc>\s*([^<]+?)\s*<\/loc>/g)].map(([, loc]) => loc.replace(/&amp;/g, '&'));
+}
+
+// Pure: the sitemap URLs a robots.txt advertises via `Sitemap:` directives.
+export function extractRobotsSitemaps(robotsTxt) {
+  return robotsTxt
+    .split(/\r?\n/)
+    .filter(line => !line.trim().startsWith('#'))
+    .flatMap(line => line.match(/^\s*Sitemap\s*:\s*(\S+)/i)?.[1] ?? []);
 }
 
 // Pure: the dist-relative path a sitemap image URL should resolve to. Sitemap
@@ -145,12 +161,55 @@ async function main() {
 
   // robots.txt: one directive per line, and a Sitemap must be advertised.
   const robotsPath = join(distDir, 'robots.txt');
-  if (await exists(robotsPath)) {
-    const robots = await readFile(robotsPath, 'utf8');
-    for (const line of findGluedRobotsDirectives(robots)) {
+  const robotsTxtBody = (await exists(robotsPath)) ? await readFile(robotsPath, 'utf8') : '';
+  if (robotsTxtBody) {
+    for (const line of findGluedRobotsDirectives(robotsTxtBody)) {
       fail(`robots.txt has glued directives on one line: "${line}"`);
     }
-    if (!/^\s*Sitemap\s*:/im.test(robots)) fail('robots.txt does not declare a Sitemap');
+    if (!/^\s*Sitemap\s*:/im.test(robotsTxtBody)) fail('robots.txt does not declare a Sitemap');
+  }
+
+  // Discovery graph. Three places enumerate our sitemaps and drift apart
+  // independently: robots.txt, the canonical sitemap-index.xml, and the
+  // conventional /sitemap.xml. Asserting one of them is what let the image
+  // sitemap ship reachable only via robots.txt, so assert the whole graph —
+  // every url set we publish must be reachable from robots.txt, and no two
+  // indexes may disagree about what exists.
+  const toName = loc => distPathForLoc(loc).replace(/^\//, '');
+  const sitemapFiles = (await readdir(distDir)).filter(name => /^sitemap.*\.xml$/.test(name));
+  const indexes = new Map();
+  const urlSets = [];
+
+  for (const name of sitemapFiles) {
+    const xml = await readFile(join(distDir, name), 'utf8');
+    if (xml.includes('<sitemapindex')) indexes.set(name, extractSitemapIndexLocs(xml).map(toName));
+    else urlSets.push(name);
+  }
+
+  // Nothing may point at a sitemap the build did not emit.
+  for (const [name, refs] of indexes) {
+    for (const ref of refs) {
+      if (!sitemapFiles.includes(ref)) fail(`${name} points at a missing sitemap: ${ref}`);
+    }
+  }
+
+  // Walk robots.txt one level down through any index it names.
+  const reachable = new Set();
+  for (const url of extractRobotsSitemaps(robotsTxtBody)) {
+    const name = toName(url);
+    if (indexes.has(name)) for (const ref of indexes.get(name)) reachable.add(ref);
+    else reachable.add(name);
+  }
+  for (const name of urlSets) {
+    if (!reachable.has(name)) fail(`${name} is unreachable from robots.txt (not advertised, and in no index it names)`);
+  }
+
+  // Two indexes listing different sets means one of them is stale.
+  const [first, ...rest] = [...indexes];
+  for (const [name, refs] of rest) {
+    const expected = [...first[1]].sort().join(', ');
+    const actual = [...refs].sort().join(', ');
+    if (expected !== actual) fail(`${name} lists [${actual}] but ${first[0]} lists [${expected}]`);
   }
 
   // The image sitemap must only advertise images the build actually emitted;

--- a/scripts/ci/check-crawl-hygiene.test.mjs
+++ b/scripts/ci/check-crawl-hygiene.test.mjs
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   distPathForLoc,
   extractImageLocs,
+  extractRobotsSitemaps,
+  extractSitemapIndexLocs,
   findArtifactViolations,
   findGluedRobotsDirectives,
   SIGNATURE_ARTIFACT,
@@ -80,6 +82,53 @@ describe('extractImageLocs', () => {
 
   it('returns nothing for a sitemap without images', () => {
     expect(extractImageLocs('<urlset><url><loc>https://dawidrylko.com/</loc></url></urlset>')).toEqual([]);
+  });
+});
+
+describe('extractSitemapIndexLocs', () => {
+  it('returns every sitemap the index points at', () => {
+    const xml =
+      '<?xml version="1.0"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
+      '<sitemap><loc>https://dawidrylko.com/sitemap-0.xml</loc><lastmod>2025-12-26T00:00:00.000Z</lastmod></sitemap>' +
+      '<sitemap><loc>https://dawidrylko.com/sitemap-images.xml</loc></sitemap></sitemapindex>';
+    expect(extractSitemapIndexLocs(xml)).toEqual([
+      'https://dawidrylko.com/sitemap-0.xml',
+      'https://dawidrylko.com/sitemap-images.xml',
+    ]);
+  });
+
+  it('does not mistake a urlset page entry for a sitemap entry', () => {
+    const xml = '<urlset><url><loc>https://dawidrylko.com/post/</loc></url></urlset>';
+    expect(extractSitemapIndexLocs(xml)).toEqual([]);
+  });
+
+  it('returns nothing for an empty index', () => {
+    expect(extractSitemapIndexLocs('<sitemapindex></sitemapindex>')).toEqual([]);
+  });
+});
+
+describe('extractRobotsSitemaps', () => {
+  it('returns every advertised sitemap, in order', () => {
+    const robots = [
+      'User-agent: *',
+      'Allow: /',
+      'Sitemap: https://dawidrylko.com/sitemap-index.xml',
+      '',
+      'Sitemap: https://dawidrylko.com/sitemap-images.xml',
+    ].join('\n');
+    expect(extractRobotsSitemaps(robots)).toEqual([
+      'https://dawidrylko.com/sitemap-index.xml',
+      'https://dawidrylko.com/sitemap-images.xml',
+    ]);
+  });
+
+  it('ignores a Sitemap mentioned inside a comment', () => {
+    const robots = '# Sitemap: https://dawidrylko.com/old.xml\nSitemap: https://dawidrylko.com/sitemap-index.xml';
+    expect(extractRobotsSitemaps(robots)).toEqual(['https://dawidrylko.com/sitemap-index.xml']);
+  });
+
+  it('returns nothing when none is declared', () => {
+    expect(extractRobotsSitemaps('User-agent: *\nAllow: /')).toEqual([]);
   });
 });
 

--- a/src/pages/metadata.astro
+++ b/src/pages/metadata.astro
@@ -29,7 +29,7 @@ const siteDescription = SITE_METADATA.description.en;
 // sitemaps and in the Pages table below, and are not machine-readable artifacts.
 const aiResources: [string, string][] = [
   ['/robots.txt', 'Crawl policy — all crawlers, AI included, are explicitly allowed; declares the sitemaps.'],
-  ['/sitemap-index.xml', 'Canonical sitemap index; the one advertised in robots.txt.'],
+  ['/sitemap-index.xml', 'Canonical sitemap index: the page URL set plus the image sitemap.'],
   ['/sitemap.xml', 'Conventional sitemap index, for crawlers that probe this path.'],
   ['/sitemap-0.xml', 'The URL set itself: every page, with lastmod and priority.'],
   ['/sitemap-images.xml', 'Google image sitemap: every post image, mapped to the page it appears on.'],

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -7,8 +7,9 @@ import type { APIRoute } from 'astro';
 // with valid XML — not an HTML meta-refresh redirect, which a strict XML parser
 // would reject — pointing at the same generated url set.
 //
-// It also carries /sitemap-images.xml, which @astrojs/sitemap cannot emit and so
-// is absent from its index; robots.txt advertises that one directly as well.
+// It lists the same set as sitemap-index.xml — including /sitemap-images.xml,
+// which sitemap() registers there through its customSitemaps option. Keep the two
+// in sync; check-crawl-hygiene.mjs fails the build when they disagree.
 export const GET: APIRoute = ({ site }) => {
   const origin = (site ?? new URL('https://dawidrylko.com')).origin;
   const body = `<?xml version="1.0" encoding="UTF-8"?>

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -38,6 +38,7 @@ Allow: /
 
 Sitemap: https://dawidrylko.com/sitemap-index.xml
 
-# Post images (Google Image sitemap extension). Declared separately because
-# @astrojs/sitemap builds sitemap-index.xml and cannot include it.
+# Every image used in a post, mapped to the page it appears on (Google image
+# sitemap extension). Also listed in the index above; repeated here so crawlers
+# that read robots.txt without following the index still find it.
 Sitemap: https://dawidrylko.com/sitemap-images.xml


### PR DESCRIPTION
## Description

`sitemap-index.xml` listed only `sitemap-0.xml`, so the index `robots.txt` advertises as canonical never reached `/sitemap-images.xml` — a manual Search Console submission or an SEO audit tool entering there saw no post images at all. `@astrojs/sitemap` does expose an extension point for this (`customSitemaps`), contrary to what #481 claimed in two comments; the index now carries both sitemaps.

Three files enumerate our sitemaps and drift apart independently, which is how #481 shipped. `check-crawl-hygiene.mjs` now asserts the whole discovery graph instead of one file.

| plik / obszar | co się zmienia |
| --- | --- |
| `astro.config.mjs` | `customSitemaps` rejestruje sitemapę obrazków w kanonicznym indeksie; `SITE` jako jedno źródło originu |
| `static/robots.txt`, `src/pages/sitemap.xml.ts` | komentarze opisują zasób, nie ograniczenie buildu (poprzednia treść była nieprawdziwa); druga linia `Sitemap:` zostaje — zero kosztu, obsługuje crawlery nieschodzące do indeksu |
| `src/pages/metadata.astro` | indeks nie jest już opisany jako „ten ogłoszony w robots.txt" — ogłoszone są oba |
| `scripts/ci/check-crawl-hygiene.mjs` | bramka na cały graf: każdy urlset osiągalny z `robots.txt`, żaden indeks nie wskazuje nieistniejącego pliku, dwa indeksy nie mogą się różnić |

Dowód: 159 testów jednostkowych, 9/9 kontraktów na `dist/`, `astro check` 0 błędów. Każdy z czterech trybów rozjazdu zweryfikowany mutacją zbudowanego `dist/` — łącznie z pierwotnym błędem (sitemapa obrazków istnieje, ale nikt jej nie wskazuje), który teraz wywala build.

## Type of change

- [x] fix — a bug fix

## Related issue

Follow-up to #481.

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)
