### PR TITLE
fix(layout): add missing space between copyright year and author link

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -161,7 +161,7 @@ const { website, person } = STRUCTURED_DATA;
       <hr />
       <footer class="footer">
         <div class="footer-copyright">
-          Copyright © {year}
+          Copyright © {year}{' '}
           <a href={SITE_METADATA.url}>{SITE_METADATA.author.name}</a>
         </div>
         <nav class="footer-metadata" aria-label="More pages">


### PR DESCRIPTION
## Description

The site footer rendered as `Copyright © 2026Dawid Ryłko` — no space before the author link. Astro trims the line-break whitespace between the `{year}` expression and the following `<a>`, so the separator has to be explicit.

| file | change |
| --- | --- |
| `src/layouts/PageLayout.astro` | `Copyright © {year}` → `Copyright © {year}{' '}`, the pattern already used in `src/demo/memoization-demo.tsx` |

Verified on a built `dist/` — `/`, `/bio/` and `/404.html` all render `Copyright © 2026 <a href="https://dawidrylko.com">Dawid Ryłko</a>`.

## Type of change

- [ ] feat — a new feature
- [x] fix — a bug fix
- [ ] docs — documentation or content
- [ ] refactor / perf / style — no behaviour change
- [ ] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)
