### PR TITLE
chore(seo): drop the named AI crawler groups from robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,41 +1,6 @@
 User-agent: *
 Allow: /
 
-# AI / LLM crawlers are explicitly welcome (same open posture as above; listed
-# so the intent is unambiguous to operators that look for a named user-agent).
-User-agent: GPTBot
-Allow: /
-
-User-agent: ChatGPT-User
-Allow: /
-
-User-agent: OAI-SearchBot
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-Web
-Allow: /
-
-User-agent: anthropic-ai
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: Google-Extended
-Allow: /
-
-User-agent: Applebot-Extended
-Allow: /
-
-User-agent: CCBot
-Allow: /
-
-# Structured site summary for AI/LLM crawlers (see also /metadata/).
-# llms.txt: https://dawidrylko.com/llms.txt
-
 Sitemap: https://dawidrylko.com/sitemap-index.xml
 
 # Every image used in a post, mapped to the page it appears on (Google image


### PR DESCRIPTION
## Description

`robots.txt` carried ten named `User-agent` groups (GPTBot, ClaudeBot, Google-Extended, …) that each repeated nothing but `Allow: /`. Per Google's spec a named group does not inherit from the `*` group, so each one silently exempted its crawler from every future global rule while changing nothing today — the first `Disallow` added to `*` would have missed exactly those ten bots. Two of the tokens were stale as well: `Claude-Web` and `anthropic-ai` are absent from Anthropic's current crawler documentation.

Their stated purpose was signalling intent to operators that scan for a named token, not crawl control. That signal is dropped deliberately, in exchange for keeping `*` authoritative for every crawler. Crawler-visible behaviour is unchanged: every bot still resolves to `User-agent: * / Allow: /`.

The image-sitemap `Sitemap:` line and the comment explaining it **stay** — that redundancy was decided in a4f35bf and is left untouched here.

Verified on a clean tree (`git archive HEAD`, without the author's untracked draft): Astro build, 11 `scripts/ci/check-*.mjs` gates and 159 Vitest tests pass.

## Type of change

- [x] ci / build / chore / test — tooling and infrastructure

## Related issue

none

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)
