### PR TITLE
chore(seo): advertise only the sitemap index in robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -2,8 +2,3 @@ User-agent: *
 Allow: /
 
 Sitemap: https://dawidrylko.com/sitemap-index.xml
-
-# Every image used in a post, mapped to the page it appears on (Google image
-# sitemap extension). Also listed in the index above; repeated here so crawlers
-# that read robots.txt without following the index still find it.
-Sitemap: https://dawidrylko.com/sitemap-images.xml


### PR DESCRIPTION
## Description

Follow-up to #484. That PR kept the direct `Sitemap:` line for the image sitemap, on the grounds — inherited from a4f35bf — that it covers crawlers which read `robots.txt` but do not follow the index. Measuring the build shows the line rescues nothing: **all 112 image URLs it lists also appear in the post HTML**, and the page sitemap's URLs are reachable from the nav, so both sitemaps stay discoverable by ordinary crawl with or without it.

The argument was also applied to only one of the two sitemaps. It holds identically for the page sitemap, which never had a direct line — so the file defended the sitemap that needs it least. Advertising the index alone removes that inconsistency, matches Google's guidance, and aligns with ADR 0061 on cyberkatalog.pl, where the same argument was rejected today for the same reason.

`sitemap-images.xml` stays reachable through `sitemap-index.xml`; `check-crawl-hygiene.mjs` asserts that graph and passes.

Verified on a clean tree (`git archive HEAD`): Astro build, 11 `scripts/ci/check-*.mjs` gates and 159 Vitest tests pass.

## Type of change

- [x] ci / build / chore / test — tooling and infrastructure

## Related issue

Follow-up to #484

## Checklist

- [x] `pnpm type:check`, `pnpm lint:check`, `pnpm lint:css`, `pnpm format:check` and `pnpm test` pass locally
- [x] PR title follows Conventional Commits
- [x] No AI attribution in commit messages or this description
- [x] Existing post URLs are preserved (SEO)
